### PR TITLE
Check environment existence before cleanup

### DIFF
--- a/.github/actions/setup-env/action.yaml
+++ b/.github/actions/setup-env/action.yaml
@@ -8,19 +8,6 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
         cache: 'pip'
-    - name: Cache conda env
-      id: cache-conda
-      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
-      env:
-        cache-name: conda-env-cache
-      with:
-        cache: 'pip'
-        path: '/usr/share/miniconda/envs'
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/environment.yml') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
     - name: Create Environment
       shell: bash
       if: ${{ steps.cache-conda.outputs.cache-hit == false }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,7 @@ jobs:
   build-recipe:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - run: |
           source $CONDA/bin/activate
           conda create --name build-env -y python=3.11 conda-build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,4 +43,4 @@ jobs:
           source $CONDA/bin/activate
           conda create --name build-env -y python=3.11 conda-build
           conda activate build-env
-          conda build -c defaults recipe/meta.yaml
+          conda build -c distro-tooling recipe/meta.yaml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,30 +36,3 @@ jobs:
             source $CONDA/bin/activate
             conda activate anaconda-linter
             make test
-  build-recipe:
-      runs-on: ubuntu-latest
-      steps:
-        - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-          with:
-            repository: AnacondaRecipes/anaconda-linter-feedstock
-            path: ./feedstock
-        - name: Cache conda env
-          id: cache-conda
-          uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
-          env:
-            cache-name: conda-env-cache
-          with:
-            path: '/usr/share/miniconda/envs'
-            key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/environment.yml') }}
-            restore-keys: |
-              ${{ runner.os }}-build-${{ env.cache-name }}-
-              ${{ runner.os }}-build-
-              ${{ runner.os }}-
-        - name: Build package
-          run: |
-            cp -r ./feedstock/abs.yaml ./feedstock/recipe .
-            source $CONDA/bin/activate
-            conda install conda-build
-            conda remove conda-anaconda-telemetry -y
-            conda-build -c distro-tooling .

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,35 +4,42 @@ on:
       - main
   pull_request:
 
-
 name: Test
 
 jobs:
   # NOTE: Tests run via `pre-commit`
   pre-commit:
-      runs-on: ubuntu-latest
-      steps:
-        - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        - uses: ./.github/actions/setup-env
-          with:
-            python-version: "3.11"
-        # Executes `pre-commit` with the `make` directive to ensure all dependencies are found
-        - run: |
-            source $CONDA/bin/activate
-            conda activate anaconda-linter
-            make pre-commit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ./.github/actions/setup-env
+        with:
+          python-version: "3.11"
+      # Executes `pre-commit` with the `make` directive to ensure all dependencies are found
+      - run: |
+          source $CONDA/bin/activate
+          conda activate anaconda-linter
+          make pre-commit
   test:
-      runs-on: ubuntu-latest
-      name: Test on ${{ matrix.python-version }}
-      strategy:
-        matrix:
-          python-version: ["3.11"] # TODO: Bump this to 3.12 when supported and drop 3.11 (covered in pre-commit)
-      steps:
-        - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        - uses: ./.github/actions/setup-env
-          with:
-            python-version: ${{ matrix.python-version }}
-        - run: |
-            source $CONDA/bin/activate
-            conda activate anaconda-linter
-            make test
+    runs-on: ubuntu-latest
+    name: Test on ${{ matrix.python-version }}
+    strategy:
+      matrix:
+        python-version: ["3.11"] # TODO: Bump this to 3.12 when supported and drop 3.11 (covered in pre-commit)
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ./.github/actions/setup-env
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: |
+          source $CONDA/bin/activate
+          conda activate anaconda-linter
+          make test
+  build-recipe:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          source $CONDA/bin/activate
+          conda create --name build-env -y python=3.11 conda-build
+          conda activate build-env
+          conda build -c defaults recipe/meta.yaml

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,10 @@ clean-build: ## remove build artifacts
 	find . -name '*.egg' -exec rm -f {} +
 
 clean-env:					## remove conda environment
-	conda remove -y -n $(CONDA_ENV_NAME) --all
+	# In `conda@v25.5.0`, deletion of a non-existent conda environment returns an error code.
+	if conda env list | grep -q "^$(CONDA_ENV_NAME) "; then \
+		conda remove -y -n $(CONDA_ENV_NAME) --all; \
+	fi
 
 clean-pyc: ## remove Python file artifacts
 	find . -name '*.pyc' -exec rm -f {} +

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -65,3 +65,4 @@ extra:
   recipe-maintainers:
     - marcoesters
     - schuylermartin45
+    - msentissi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,67 @@
+{% set version = "0.1.5" %}
+
+package:
+  name: anaconda-linter
+  version: {{ version }}
+
+source:
+  path: ../
+
+build:
+  number: 0
+  noarch: python
+  script: pip install . --no-deps --no-build-isolation -vv
+  entry_points:
+    - conda-lint = anaconda_linter.run:main
+    - anaconda-lint = anaconda_linter.run:main
+
+requirements:
+  host:
+    - python
+    - pip
+    - setuptools
+    - wheel
+  run:
+    - python >=3.11
+    - requests
+    - ruamel.yaml
+    - license-expression
+    - jinja2
+    - conda-build
+    - jsonschema
+    - networkx
+    - percy >=0.1.3
+
+test:
+  source_files:
+    - tests
+  requires:
+    - pip
+    - pytest
+  imports:
+    - anaconda_linter
+    - anaconda_linter.lint
+  commands:
+    - pip check
+    # Check entry points
+    - anaconda-lint -h
+    - conda-lint -h
+    # lint_list is only an important test for development
+    - python -m pytest tests -k "not lint_list"
+
+about:
+  home: https://github.com/anaconda-distribution/anaconda-linter
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  summary: A conda feedstock linter written in pure Python.
+  description: |
+    Runs a range of static checks on conda feedstocks. Under
+    ongoing development.
+  doc_url: https://github.com/anaconda-distribution/anaconda-linter/blob/main/README.md
+  dev_url: https://github.com/anaconda-distribution/anaconda-linter
+
+extra:
+  recipe-maintainers:
+    - marcoesters
+    - schuylermartin45


### PR DESCRIPTION
**Description**
 - Starting from version 24.9.0, [conda raises an error](https://github.com/conda/conda/releases/tag/24.9.0) when attempting to remove a non-existent environment.
 - This causes `clean-env` to fail the first time that `make dev` is run, since the environment doesn't exist and we attempt to remove it.

**Fix**
- Check whether the environment exists. If so, remove it, otherwise move on.