### PR TITLE
add parsing failure statistics scripts

### DIFF
--- a/scripts/analyze_local_recipes.py
+++ b/scripts/analyze_local_recipes.py
@@ -1,0 +1,229 @@
+# type: ignore
+"""
+Script to analyze locally downloaded conda recipes and collect parsing failure statistics.
+
+This script reads meta.yaml files from a local directory (downloaded by download_aggregate_recipes.py)
+and generates reports and visualizations of RecipeReader success/failure statistics.
+"""
+import os
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Dict, Tuple
+
+import matplotlib.pyplot as plt
+from conda_recipe_manager.parser.recipe_reader import RecipeReader
+
+
+def capture_exception_details(exception: Exception, feedstock_name: str) -> Dict[str, str]:
+    """
+    Capture the root cause file and line number where an exception occurred.
+
+    :param exception: The exception object to analyze
+    :param feedstock_name: Name of the feedstock where the exception occurred
+    :returns: Dictionary containing exception details with keys:
+        - feedstock: Name of the feedstock
+        - type: Exception class name
+        - message: Exception message
+        - root_cause_file: Filename where error occurred
+        - root_cause_line: Line number where error occurred
+    """
+    root_cause_file = None
+    root_cause_line = None
+
+    # Find the deepest conda-recipe-manager frame
+    tb = exception.__traceback__
+    while tb:
+        filename = tb.tb_frame.f_code.co_filename
+        if "conda_recipe_manager" in filename:
+            root_cause_file = os.path.basename(filename)
+            root_cause_line = tb.tb_lineno
+        tb = tb.tb_next
+
+    return {
+        "feedstock": feedstock_name,
+        "type": exception.__class__.__name__,
+        "message": str(exception),
+        "root_cause_file": root_cause_file,
+        "root_cause_line": root_cause_line,
+    }
+
+
+def analyze_local_recipes(
+    input_dir_path: str = "~/conda-recipe-manager-aggregate-test-data",
+) -> Tuple[Counter, int, defaultdict]:
+    """
+    Analyze all locally saved recipes and collect exception statistics.
+
+    :param input_dir_path: Path to directory containing downloaded recipe files
+    :returns: A tuple containing:
+        - exception_counter (Counter): Counter of exception types
+        - success_count (int): Number of successful RecipeReader creations
+        - recipe_details (defaultdict): Detailed exception information grouped by type
+    """
+    recipe_details = defaultdict(list)
+    success_count = 0
+
+    # Expand user path
+    input_dir = Path(input_dir_path).expanduser()
+
+    if not input_dir.exists():
+        print(f"Input directory does not exist: {input_dir}")
+        print("Please run download_aggregate_recipes.py first to download the recipes.")
+        return Counter(), success_count, recipe_details
+
+    # Find all .yaml files in the directory
+    recipe_files = list(input_dir.glob("*.yaml"))
+    total_count = len(recipe_files)
+
+    if total_count == 0:
+        print(f"No .yaml files found in {input_dir}")
+        return Counter(), success_count, recipe_details
+
+    print(f"Found {total_count} recipe files in {input_dir}")
+    print("Starting analysis...")
+
+    # Process each recipe file
+    for i, recipe_file in enumerate(recipe_files, 1):
+        feedstock_name = recipe_file.stem  # Remove .yaml extension
+
+        if i % 100 == 0:
+            print(f"Processed {i}/{total_count}")
+
+        # Try to parse with RecipeReader
+        try:
+            RecipeReader(recipe_file.read_text())
+            success_count += 1
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            exception_info = capture_exception_details(e, feedstock_name)
+            exception_type = exception_info["type"]
+            recipe_details[exception_type].append(exception_info)
+
+    print(f"\nCompleted analysis of {total_count} recipes.")
+    print(f"Successful: {success_count} ({success_count/total_count*100:.1f}%)")
+    print(f"Failed: {total_count - success_count} ({100 - success_count/total_count*100:.1f}%)")
+
+    # Create counter from recipe_details
+    exception_counter = Counter({exc_type: len(details) for exc_type, details in recipe_details.items()})
+
+    return exception_counter, success_count, recipe_details
+
+
+def generate_histogram(exception_counter: Counter, success_count: int) -> None:
+    """
+    Generate and display histogram of exceptions.
+
+    :param exception_counter: Counter of exception types and their frequencies
+    :param success_count: Number of successful RecipeReader creations
+    """
+    # Prepare data for histogram
+    labels = list(exception_counter.keys()) + ["Success"]
+    counts = list(exception_counter.values()) + [success_count]
+
+    # Create histogram
+    plt.figure(figsize=(15, 8))
+    bars = plt.bar(range(len(labels)), counts)
+
+    # Customize the plot
+    plt.xlabel("Exception Types")
+    plt.ylabel("Frequency")
+    plt.title("RecipeReader Exceptions and Successes")
+    plt.xticks(range(len(labels)), labels, rotation=45, ha="right")
+
+    # Add value labels on bars
+    for bar, count in zip(bars, counts):
+        plt.text(bar.get_x() + bar.get_width() / 2, bar.get_height() + 0.1, str(count), ha="center", va="bottom")
+
+    # Color successful bars differently
+    bars[-1].set_color("green")  # Success bar in green
+
+    plt.tight_layout()
+
+    # Show the plot
+    plt.show()
+
+
+def print_detailed_report(exception_counter: Counter, success_count: int, recipe_details: defaultdict) -> None:
+    """
+    Print a detailed report of the analysis results.
+
+    :param exception_counter: Counter of exception types and their frequencies
+    :param success_count: Number of successful RecipeReader creations
+    :param recipe_details: Detailed exception information grouped by exception type
+    """
+    total = sum(exception_counter.values()) + success_count
+
+    print("\n" + "=" * 50)
+    print("RECIPE ANALYSIS REPORT")
+    print("=" * 50)
+    print(f"Total recipes: {total}")
+    print(f"Successful: {success_count} ({success_count/total*100:.1f}%)")
+    print(f"Failed: {sum(exception_counter.values())} ({sum(exception_counter.values())/total*100:.1f}%)")
+
+    print("\nException breakdown:")
+    print("-" * 30)
+    for exception_type, count in exception_counter.most_common():
+        print(f"{exception_type:30} {count:6d} ({count/total*100:5.1f}%)")
+
+    print("\nDetailed exception analysis:")
+    print("-" * 60)
+    for exception_type, exception_details in recipe_details.items():
+        print(f"\n{exception_type} ({exception_counter[exception_type]} occurrences):")
+
+        # Group by unique combination of message, root cause file, and root cause line
+        groups = defaultdict(list)
+        for detail in exception_details:
+            key = (detail["message"], detail["root_cause_file"], detail["root_cause_line"])
+            groups[key].append(detail)
+
+        # Display each unique combination
+        for i, (key, details_list) in enumerate(sorted(groups.items()), 1):
+            message, root_cause_file, root_cause_line = key
+            count = len(details_list)
+
+            print(f"  {i}. Message: {message}")
+            if root_cause_file:
+                print(f"     Root cause file: {root_cause_file}")
+            if root_cause_line:
+                print(f"     Root cause line: {root_cause_line}")
+            print(f"     Count: {count}")
+
+            # Show examples
+            examples = [d["feedstock"] for d in details_list[:5]]
+            examples_str = ", ".join(examples)
+            print(f"     Examples: {examples_str}")
+            if len(details_list) > 5:
+                print(f"     ... and {len(details_list) - 5} more")
+
+            print()
+
+
+def main():
+    """
+    Main function to run the recipe analysis.
+
+    This function orchestrates the complete analysis workflow:
+
+    1. Analyzes local recipe files for parsing errors
+    2. Prints a detailed report of results
+    3. Generates and displays a histogram visualization
+    """
+    print("Starting analysis of locally downloaded recipes")
+
+    # Analyze recipes
+    exception_counter, success_count, recipe_details = analyze_local_recipes()
+
+    if sum(exception_counter.values()) + success_count == 0:
+        print("No recipes to analyze. Exiting.")
+        return
+
+    # Print detailed report
+    print_detailed_report(exception_counter, success_count, recipe_details)
+
+    # Generate histogram
+    generate_histogram(exception_counter, success_count)
+
+    print("\nAnalysis complete!")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/download_aggregate_recipes.py
+++ b/scripts/download_aggregate_recipes.py
@@ -1,0 +1,116 @@
+# type: ignore
+"""
+Script to download all conda recipes from AnacondaRecipes/aggregate repository.
+"""
+import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import List, Optional
+
+from dotenv import load_dotenv
+from github import Github
+
+
+def fetch_submodules(github_token: Optional[str] = None) -> List[str]:
+    """
+    Fetch all feedstock submodule paths from AnacondaRecipes/aggregate repository.
+
+    :param github_token: GitHub token for authentication
+    :returns: List of feedstock submodule paths
+    """
+    g = Github(github_token)
+    repo = g.get_repo("AnacondaRecipes/aggregate")
+    content = repo.get_contents(".gitmodules").decoded_content.decode("utf-8")
+
+    # Extract feedstock paths from .gitmodules
+    submodules = []
+    lines = content.strip().split("\n")
+    i = 0
+    while i < len(lines):
+        line = lines[i].strip()
+        if line.startswith('[submodule "') and line.endswith('-feedstock"]'):
+            # Find the corresponding path line
+            for j in range(i + 1, min(i + 3, len(lines))):
+                if lines[j].strip().startswith("path = "):
+                    path = lines[j].strip().split("= ", 1)[1]
+                    submodules.append(path)
+                    break
+        i += 1
+
+    print(f"Found {len(submodules)} feedstock submodules")
+    return submodules
+
+
+def download_recipe(feedstock_path: str, output_dir: Path, github_token: Optional[str] = None) -> bool:
+    """
+    Download meta.yaml from a feedstock repository.
+
+    :param feedstock_path: Feedstock repository path
+    :param output_dir: Output directory for downloaded files
+    :param github_token: GitHub token for authentication
+    :returns: Success flag
+    """
+    output_file = output_dir / f"{feedstock_path}.yaml"
+
+    try:
+        g = Github(github_token)
+        repo = g.get_repo(f"AnacondaRecipes/{feedstock_path}")
+        content = repo.get_contents("recipe/meta.yaml").decoded_content.decode("utf-8")
+        output_file.write_text(content, encoding="utf-8")
+        return True
+    except Exception:  # pylint: disable=broad-exception-caught
+        return False
+
+
+def load_github_token() -> Optional[str]:
+    """
+    Load GitHub token from environment.
+
+    :returns: GitHub token if found
+    """
+    env_file = Path("~/.secrets/crm-failure-stats/.env").expanduser()
+
+    if env_file.exists():
+        load_dotenv(env_file)
+
+    return os.getenv("CRM_FAIL_STATS_GITHUB_TOKEN")
+
+
+def download_all_recipes(output_dir_path: str = "~/conda-recipe-manager-aggregate-test-data"):
+    """
+    Download all recipes from the aggregate repository.
+
+    :param output_dir_path: Path to output directory
+    """
+    output_dir = Path(output_dir_path).expanduser()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    github_token = load_github_token()
+    rate_limit = "5000" if github_token else "60"
+    auth_str = "authenticated" if github_token else "unauthenticated"
+    print(f"Using {auth_str} requests ({rate_limit} req/hour)")
+
+    submodules = fetch_submodules(github_token)
+    if not submodules:
+        print("No submodules found!")
+        return
+
+    print(f"Downloading {len(submodules)} recipes...")
+
+    # Download concurrently
+    results = []
+    with ThreadPoolExecutor(max_workers=5) as executor:
+        futures = {executor.submit(download_recipe, path, output_dir, github_token): path for path in submodules}
+
+        for i, future in enumerate(as_completed(futures), 1):
+            results.append(future.result())
+
+            if i % 100 == 0:
+                print(f"Processed {i}/{len(submodules)}")
+
+    success_count = sum(results)
+    print(f"\nComplete! Downloaded {success_count}/{len(submodules)} recipes to {output_dir}")
+
+
+if __name__ == "__main__":
+    download_all_recipes()


### PR DESCRIPTION
### Description

- In order to benchmark - and rapidly improve - the linter's basic stability against `aggregate`'s recipes, I'd like to introduce 2 scripts:
  - One to download all the recipes in the repos that are submodules of `aggregate`.
  - A second to attempt to construct a CRM `RecipeReader` from each recipe, and catalog the failures, so that we can address them from most to least impactful. This way, using CRM in the linter should benefit from improved stability.

The following is a sample output of the second script:

```
==================================================
RECIPE ANALYSIS REPORT
==================================================
Total recipes: 2464
Successful: 2330 (94.6%)
Failed: 134 (5.4%)

Exception breakdown:
------------------------------
IndexError                        100 (  4.1%)
ScannerError                       30 (  1.2%)
ComposerError                       2 (  0.1%)
ConstructorError                    1 (  0.0%)
ParserError                         1 (  0.0%)

Detailed exception analysis:
------------------------------------------------------------

IndexError (100 occurrences):
  1. Message: list index out of range
     Root cause file: recipe_reader.py
     Root cause line: 537
     Count: 5
     Examples: mklml-feedstock, llama.cpp-feedstock, anaconda-anon-usage-feedstock, prophet-pystan-model-feedstock, autoviml-feedstock

  2. Message: list index out of range
     Root cause file: recipe_reader.py
     Root cause line: 559
     Count: 60
     Examples: qtwebsockets-feedstock, qt5compat-feedstock, cfitsio-feedstock, slicerator-feedstock, hdf4-feedstock
     ... and 55 more

  3. Message: pop from empty list
     Root cause file: recipe_reader.py
     Root cause line: 556
     Count: 35
     Examples: gtest-feedstock, python_abi-feedstock, sentencepiece-feedstock, pango-feedstock, qtbase-feedstock
     ... and 30 more


ScannerError (30 occurrences):
  1. Message: while scanning for the next token
found character that cannot start any token
  in "<unicode string>", line 1, column 1
     Root cause file: recipe_reader.py
     Root cause line: 132
     Count: 1
     Examples: doit-feedstock

  2. Message: while scanning for the next token
found character that cannot start any token
  in "<unicode string>", line 1, column 2
     Root cause file: recipe_reader.py
     Root cause line: 132
     Count: 29
     Examples: boost-feedstock, abseil-cpp-feedstock, compilers-feedstock, scotch-feedstock, grpc-cpp-feedstock
     ... and 24 more


ConstructorError (1 occurrences):
  1. Message: while constructing a mapping
  in "<unicode string>", line 1, column 9
found unhashable key
  in "<unicode string>", line 1, column 10
     Root cause file: recipe_reader.py
     Root cause line: 132
     Count: 1
     Examples: dataclasses-feedstock


ComposerError (2 occurrences):
  1. Message: found undefined alias
  in "<unicode string>", line 1, column 7
     Root cause file: recipe_reader.py
     Root cause line: 132
     Count: 2
     Examples: cachecontrol-feedstock, pypdf-feedstock


ParserError (1 occurrences):
  1. Message: while parsing a flow mapping
  in "<unicode string>", line 1, column 4
did not find expected ',' or '}'
  in "<unicode string>", line 1, column 30
     Root cause file: recipe_reader.py
     Root cause line: 132
     Count: 1
     Examples: prophet-feedstock
```

![recipe_reader_exceptions_graph](https://github.com/user-attachments/assets/8cf795a2-5120-4bf6-931c-d54b024aa3b6)

