### PR TITLE
Lint for stdlib inclusion and placement

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,7 @@ name: Test
 
 jobs:
   # NOTE: Tests run via `pre-commit`
+  # TODO: These are linting/code analysis checks. Do these before running a build so they get fixed early.
   pre-commit:
     runs-on: ubuntu-latest
     steps:
@@ -20,6 +21,20 @@ jobs:
           source $CONDA/bin/activate
           conda activate anaconda-linter
           make pre-commit
+
+  # Skip tests during build since they happen in their own stage.
+  build-recipe:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - run: |
+          source $CONDA/bin/activate
+          conda create --name build-env -y python=3.11 conda-build
+          conda activate build-env
+          conda build -c distro-tooling --no-test recipe/meta.yaml
+
+  # TODO: This stage should be dependent on the build stage and test the same package that was just built instead of
+  #       independently running pytest.
   test:
     runs-on: ubuntu-latest
     name: Test on ${{ matrix.python-version }}
@@ -35,12 +50,3 @@ jobs:
           source $CONDA/bin/activate
           conda activate anaconda-linter
           make test
-  build-recipe:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - run: |
-          source $CONDA/bin/activate
-          conda create --name build-env -y python=3.11 conda-build
-          conda activate build-env
-          conda build -c distro-tooling recipe/meta.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,29 @@
 # Changelog
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+
 Note: version releases in the 0.x.y range may introduce breaking changes.
 
-## 0.1.5
+
+## [Unreleased]
+### Added
+- Platform stdlib name enumeration `anaconda_linter.lint.check_build_help.STDLIBS` containing `sysroot`,
+`macosx_deployment_target`, `vs` values
+- `should_use_stdlib`
+  - Checks if `stdlib('c')` is included in recipes with compilers
+  - Checks if stdlib packages are used directly in recipes instead of the Jinja macro
+- `stdlib_must_be_in_build`
+  - Checks if `stdlib('c')` is used in `host:` or `run:` sections instead of `build:`
+- Tests for new `stdlib('c')` linter build checks
+### Changed
+- Updated embedded `conda_build_config.yaml` to reflect current config file in aggregate
+### Deprecated
+### Removed
+### Fixed
+- Bug where unknown Jinja macros in requirements sections would cause linter to crash
+### Security
+
+## [0.1.5]
 - Bug fix: calls to get_read_only_parser result in unhandled errors on some recipes
 
 ## 0.1.4
@@ -93,3 +115,7 @@ Note: version releases in the 0.x.y range may introduce breaking changes.
 
 Initial release:
 - To support downloading of tarballs like: https://github.com/anaconda-distribution/anaconda-linter/archive/{{ version }}.tar.gz
+
+
+[Unreleased]: https://github.com/anaconda/percy/compare/0.1.5...HEAD
+[0.1.5]: https://github.com/anaconda/percy/compare/0.1.4...0.1.5

--- a/anaconda_linter/data/cbc_default.yaml
+++ b/anaconda_linter/data/cbc_default.yaml
@@ -5,6 +5,7 @@ linux: 0
 arch: None
 platform: None
 c_compiler: None
+c_stdlib: None
 vc: None
 target_platform: None
 build_platform: None

--- a/anaconda_linter/data/cbc_linux-64.yaml
+++ b/anaconda_linter/data/cbc_linux-64.yaml
@@ -1,5 +1,6 @@
 arch: 64       # ppc64le aarch64 ppc64 s390x win
 platform: linux  # linux os win
+c_stdlib: sysroot
 target_platform: linux-64
 build_platform: linux-64
 ccache_method: None

--- a/anaconda_linter/data/cbc_linux-aarch64.yaml
+++ b/anaconda_linter/data/cbc_linux-aarch64.yaml
@@ -2,6 +2,7 @@ arch: aarch64       # ppc64le aarch64 ppc64 s390x win
 platform: linux  # linux os win
 target_platform: linux-aarch64
 build_platform: linux-aarch64
+c_stdlib: sysroot
 ccache_method: None
 lang_c: gcc
 lang_cxx: gxx

--- a/anaconda_linter/data/cbc_linux-ppc64le.yaml
+++ b/anaconda_linter/data/cbc_linux-ppc64le.yaml
@@ -2,6 +2,7 @@ arch: ppc64le       # ppc64le aarch64 ppc64 s390x win
 platform: linux  # linux os win
 target_platform: linux-ppc64le
 build_platform: linux-ppc64le
+c_stdlib: sysroot
 ccache_method: None
 lang_c: gcc
 lang_cxx: gxx

--- a/anaconda_linter/data/cbc_linux-s390x.yaml
+++ b/anaconda_linter/data/cbc_linux-s390x.yaml
@@ -2,6 +2,7 @@ arch: s390x       # ppc64le aarch64 ppc64 s390x win
 platform: linux  # linux os win
 target_platform: linux-s390x
 build_platform: linux-s390x
+c_stdlib: sysroot
 ccache_method: None
 lang_c: gcc
 lang_cxx: gxx

--- a/anaconda_linter/data/cbc_osx-64.yaml
+++ b/anaconda_linter/data/cbc_osx-64.yaml
@@ -2,6 +2,7 @@ arch: 64       # ppc64le aarch64 ppc64 s390x win
 platform: osx # linux os win
 target_platform: osx-64
 build_platform: osx-64
+c_stdlib: macosx_deployment_target
 ccache_method: None
 lang_c: clang
 lang_cxx: clangxx

--- a/anaconda_linter/data/cbc_osx-arm64.yaml
+++ b/anaconda_linter/data/cbc_osx-arm64.yaml
@@ -2,6 +2,7 @@ arch: arm64       # ppc64le aarch64 ppc64 s390x win
 platform: osx # linux os win
 target_platform: osx-arm64
 build_platform: osx-arm64
+c_stdlib: macosx_deployment_target
 ccache_method: None
 lang_c: clang
 lang_cxx: clangxx

--- a/anaconda_linter/data/cbc_win-64.yaml
+++ b/anaconda_linter/data/cbc_win-64.yaml
@@ -1,12 +1,13 @@
 arch: 64       # ppc64le aarch64 ppc64 s390x win
 platform: win  # linux os win
-c_compiler: vs2017
+c_compiler: vs2019
+c_stdlib: vs
 vc: 14
 target_platform: win-64
 build_platform: win-32
 ccache_method: None
-lang_c: vs2017
-lang_cxx: vs2017
+lang_c: vs2019
+lang_cxx: vs2019
 lang_vc: 14
 lang_fortran: gfortran
 win: 1

--- a/anaconda_linter/data/conda_build_config.yaml
+++ b/anaconda_linter/data/conda_build_config.yaml
@@ -21,11 +21,15 @@ cairo:
 c_compiler:
   - gcc                        # [linux]
   - clang                      # [osx]
-  - vs2017                     # [win]
+  - vs2019                     # [win]
+c_stdlib:
+  - sysroot                    # [linux]
+  - macosx_deployment_target   # [osx]
+  - vs                         # [win]
 cxx_compiler:
   - gxx                        # [linux]
   - clangxx                    # [osx]
-  - vs2017                     # [win]
+  - vs2019                     # [win]
 fortran_compiler:
   - gfortran                   # [linux or osx]
   - intel-fortran              # [win]
@@ -40,9 +44,6 @@ rust_compiler:
   - rust-gnu                   # [win]
 rust_compiler_version:
   - 1.64.0
-CONDA_BUILD_SYSROOT:
-  - /opt/MacOSX10.10.sdk        # [osx and x86_64]
-  - /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk  # [osx and arm64]
 VERBOSE_AT:
   - V=1
 VERBOSE_CM:
@@ -53,6 +54,13 @@ cran_mirror:
 c_compiler_version:        # [linux or osx]
   - 11.2.0                 # [linux]
   - 14                     # [osx]
+c_stdlib_version:
+  - 2.17                   # [linux and x86_64 and (not ANACONDA_ROCKET_GLIBC or ANACONDA_ROCKET_GLIBC == "2.17")]
+  - 2.26                   # [linux and aarch64 and (not ANACONDA_ROCKET_GLIBC or ANACONDA_ROCKET_GLIBC == "2.26")]
+  - 2.28                   # [linux and ANACONDA_ROCKET_GLIBC == "2.28"]
+  - 10.15                  # [osx and x86_64]
+  - 11.1                   # [osx and arm64]
+  - 2019.11                # [win]
 cxx_compiler_version:      # [linux or osx]
   - 11.2.0                 # [linux]
   - 14                     # [osx]
@@ -64,6 +72,33 @@ clang_variant:
 cyrus_sasl:
   - 2.1.26  # [not ((osx and arm64) or (linux and aarch64))]
   - 2.1.27  # [(osx and arm64) or (linux and aarch64)]
+
+cdt_name:          # [linux]
+  - amzn2          # [linux and aarch64 and (not ANACONDA_ROCKET_GLIBC or ANACONDA_ROCKET_GLIBC == "2.26")]
+  - el8            # [linux and ANACONDA_ROCKET_GLIBC == "2.28"]
+
+# https://github.com/conda/conda-build/issues/5733
+BUILD: x86_64-conda_el8-linux-gnu   # [linux and x86_64 and ANACONDA_ROCKET_GLIBC == "2.28"]
+BUILD: aarch64-conda_el8-linux-gnu  # [linux and aarch64 and ANACONDA_ROCKET_GLIBC == "2.28"]
+
+OSX_SDK_DIR:
+  - /opt                                      # [osx and x86_64]
+  - /Library/Developer/CommandLineTools/SDKs  # [osx and arm64]
+# TODO: These are only necessary as we transition to using the stdlib('c') macro. They should be
+#       removed once it is safe to do so.
+CONDA_BUILD_SYSROOT:
+  - /opt/MacOSX10.15.sdk        # [osx and x86_64]
+  - /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk  # [osx and arm64]
+macos_min_version:
+  - 10.15 # [osx and x86_64]
+  - 11.1  # [osx and arm64]
+macos_machine:
+  - x86_64-apple-darwin13.4.0  # [osx and x86_64]
+  - arm64-apple-darwin20.0.0   # [osx and arm64]
+MACOSX_DEPLOYMENT_TARGET:
+  - 10.15 # [osx and x86_64]
+  - 11.1  # [osx and arm64]
+
 dbus:
   - 1
 expat:
@@ -138,15 +173,6 @@ llvm_variant:
   - llvm
 lzo:
   - 2
-macos_min_version:
-  - 10.9  # [osx and x86_64]
-  - 11.1  # [osx and arm64]
-macos_machine:
-  - x86_64-apple-darwin13.4.0  # [osx and x86_64]
-  - arm64-apple-darwin20.0.0   # [osx and arm64]
-MACOSX_DEPLOYMENT_TARGET:
-  - 10.9  # [osx and x86_64]
-  - 11.1  # [osx and arm64]
 mkl:
   - 2023.*
 mpfr:
@@ -221,8 +247,6 @@ xz:
   - 5
 channel_targets:
   - defaults
-cdt_name:
-  - amzn2    # [linux and aarch64]
 zip_keys:
   -
     - python

--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import os
 import re
 from pathlib import Path
-from typing import Any
+from typing import Any, Final
 
 from conda_recipe_manager.parser.recipe_reader_deps import RecipeReaderDeps
 from percy.parser.recipe_parser import RecipeParser, SelectorConflictMode
@@ -18,7 +18,7 @@ from anaconda_linter import utils as _utils
 from anaconda_linter.lint import LintCheck, Severity
 
 # Does not include m2-tools, which should be checked using wild cards.
-BUILD_TOOLS = (
+BUILD_TOOLS: Final[tuple] = (
     "autoconf",
     "automake",
     "bison",
@@ -35,7 +35,7 @@ BUILD_TOOLS = (
     "posix",
 )
 
-PYTHON_BUILD_TOOLS = (
+PYTHON_BUILD_TOOLS: Final[tuple] = (
     "cython",
     "flit",
     "flit-core",
@@ -66,7 +66,7 @@ PYTHON_BUILD_TOOLS = (
 # Historical note: pyproject.toml file was introduced initially to specify the build system (backend).
 # Only later was the ability to specify all the project metadata (name, version, dependencies, etc)
 # into it added, via PEP-621.
-PYTHON_BUILD_BACKENDS = (
+PYTHON_BUILD_BACKENDS: Final[tuple] = (
     "flit",  # Our packages are not supposed to depend on flit, but apparently they do, so we need to support it here.
     "flit-core",  # Backend of flit.
     "hatch",  # Same as flit, we should not depend on it. We should instead depend on hatchling, which is the backend.
@@ -80,7 +80,7 @@ PYTHON_BUILD_BACKENDS = (
     "maturin",
 )
 
-COMPILERS = (
+COMPILERS: Final[tuple] = (
     "cgo",
     "cuda",
     "dpcpp",
@@ -100,7 +100,7 @@ COMPILERS = (
     "toolchain",
 )
 
-STDLIBS = ("sysroot", "macosx_deployment_target", "vs")  # linux  # osx  # windows
+STDLIBS: Final[tuple] = ("sysroot", "macosx_deployment_target", "vs")  # linux  # osx  # windows
 
 
 def is_pypi_source(recipe: Recipe) -> bool:

--- a/anaconda_linter/lint/check_syntax.py
+++ b/anaconda_linter/lint/check_syntax.py
@@ -34,6 +34,9 @@ class version_constraints_missing_whitespace(LintCheck):
         for path in check_paths:
             output = -1 if not path.startswith("outputs") else int(path.split("/")[1])
             for n, spec in enumerate(recipe.get(path, [])):
+                if spec is None:
+                    continue
+
                 has_constraints = constraints.search(spec)
                 if has_constraints:
                     # The second condition is a fallback.

--- a/anaconda_linter/lint_names.md
+++ b/anaconda_linter/lint_names.md
@@ -123,3 +123,7 @@ cbc_dep_in_run_missing_from_host
 wrong_output_script_key
 
 potentially_bad_ignore_run_exports
+
+should_use_stdlib
+
+stdlib_must_be_in_build

--- a/environment.yaml
+++ b/environment.yaml
@@ -9,7 +9,7 @@ dependencies:
   - pip
   - make
   # run
-  - distro-tooling::percy >=0.1.5
+  - distro-tooling::percy >=0.2.5
   - distro-tooling::anaconda-packaging-utils
   - ruamel.yaml
   - license-expression

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - conda-build
     - jsonschema
     - networkx
-    - percy >=0.1.3
+    - percy >=0.2.5
     - conda-recipe-manager
 
 test:


### PR DESCRIPTION
### Added
- Platform stdlib name enumeration `anaconda_linter.lint.check_build_help.STDLIBS` containing `sysroot`,
`macosx_deployment_target`, `vs` values
- `should_use_stdlib`
  - Checks if `stdlib('c')` is included in recipes with compilers
  - Checks if stdlib packages are used directly in recipes instead of the Jinja macro
- `stdlib_must_be_in_build`
  - Checks if `stdlib('c')` is used in `host:` or `run:` sections instead of `build:`
- Tests for new `stdlib('c')` linter build checks
### Changed
- Updated embedded `conda_build_config.yaml` to reflect current config file in aggregate
### Fixed
- Bug where unknown Jinja macros in requirements sections would cause linter to crash