### PR TITLE
Setup CRM compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,12 @@ dev: clean  ## install the package's development version
 	conda run --name $(CONDA_ENV_NAME) pip install -e .
 	$(CONDA_ACTIVATE) $(CONDA_ENV_NAME) && pre-commit install
 
+dev-crm: clean
+	conda env create -f environment_dev_crm.yaml --name $(CONDA_ENV_NAME) --yes
+	conda run --name $(CONDA_ENV_NAME) pip install -e $(CRM_PATH)
+	conda run --name $(CONDA_ENV_NAME) pip install -e .
+	$(CONDA_ACTIVATE) $(CONDA_ENV_NAME) && pre-commit install
+
 pre-commit:     ## runs pre-commit against files. NOTE: older files are disabled in the pre-commit config.
 	pre-commit run --all-files
 

--- a/anaconda_linter/lint/__init__.py
+++ b/anaconda_linter/lint/__init__.py
@@ -945,7 +945,6 @@ class Linter:
                 if self.nocatch:
                     raise
                 logger.exception("Unexpected exception in lint_recipe")
-                # TODO: Adapt LintMessage to CRM recipes
                 res = [
                     LintMessage(
                         recipe=recipe,

--- a/anaconda_linter/lint/__init__.py
+++ b/anaconda_linter/lint/__init__.py
@@ -318,8 +318,9 @@ class LintCheck(metaclass=LintCheckMeta):
                 recipe=self.recipe,
                 fname=recipe_name,
                 severity=Severity.ERROR,
-                title_in="An unexpected error occurred in CRM. "
-                "Please report this issue to the pi-automation team through the #pi-automation channel.",
+                title_in="An unexpected error occurred in the linter. "
+                "Please describe the issue in https://github.com/anaconda/anaconda-linter/issues/new, "
+                "and we will fix it as soon as possible.",
                 body_in="",
             )
             return [message]
@@ -332,8 +333,9 @@ class LintCheck(metaclass=LintCheckMeta):
                 recipe=self.percy_recipe,
                 fname=recipe_name,
                 severity=Severity.ERROR,
-                title_in="An unexpected error occurred in Percy. "
-                "Please report this issue to the pi-automation team through the #pi-automation channel.",
+                title_in="An unexpected error occurred in the linter. "
+                "Please describe the issue in https://github.com/anaconda/anaconda-linter/issues/new, "
+                "and we will fix it as soon as possible.",
                 body_in="",
             )
             return [message]

--- a/anaconda_linter/lint/__init__.py
+++ b/anaconda_linter/lint/__init__.py
@@ -801,11 +801,11 @@ class Linter:
             print(f"Linting subdir:{arch_name} recipe:{recipe_name}")
 
         # Gather variants for specified subdir
-        # As a stopgap, this process outputs a tuple with
+        # As a stopgap, this process outputs a tuple per variant with
         # variants and variant info using Percy
         # TODO: replace with CRM variants generation
         # TODO: track recipe variants (python version, arch, etc.) all the way to error reporting to ease fixing
-        recipe_variants: list[tuple[dict, RecipeReaderDeps]] = []
+        recipe_variants: list[tuple] = []
         try:
             meta_yaml = Path(recipe_name) / "meta.yaml"
             if (Path(__file__) / "conda_build_config.yaml").is_file():

--- a/anaconda_linter/lint/__init__.py
+++ b/anaconda_linter/lint/__init__.py
@@ -418,8 +418,8 @@ class LintCheck(metaclass=LintCheckMeta):
         :param output: the output the error occurred in (multi-output recipes only)
         """
         # In order to handle Percy-based rules generating messages with a section
-        # We must adapt the section by adding a slash to the section
-        if section:
+        # We must adapt the section by prepending a slash
+        if section and not section.startswith("/"):
             section = "/" + section
         # This should only happen during testing
         if not self.recipe_path:

--- a/anaconda_linter/lint/__init__.py
+++ b/anaconda_linter/lint/__init__.py
@@ -882,8 +882,7 @@ class Linter:
                             fix=fix,
                         )
                     )
-            # TODO: Implement auto-fixing without overwriting each variant
-            # TODO: Implement CRM exception handling, and adapt LintCheck, including message() and make_message()
+            # TODO: Implement auto-fixing when variant generation is implemented
         except Exception:  # pylint: disable=broad-exception-caught
             recipe = _recipe.Recipe(recipe_name)
             return [linter_failure.make_message(recipe=recipe, fname=recipe_name)]

--- a/anaconda_linter/lint/__init__.py
+++ b/anaconda_linter/lint/__init__.py
@@ -400,6 +400,7 @@ class LintCheck(metaclass=LintCheckMeta):
     def message(
         self,
         *args,
+        fname: str | Path | None = None,
         section: str = "",
         severity: Severity = SEVERITY_DEFAULT,
         data: Any = None,
@@ -411,6 +412,7 @@ class LintCheck(metaclass=LintCheckMeta):
         Also calls `fix` if we are supposed to be fixing.
 
         :param args: Additional arguments to pass directly to the message
+        :param fname: If specified, the message will apply to this file, rather than the recipe meta.yaml
         :param section: If specified, a lint location within the recipe meta.yaml pointing to this section/subsection
             will be added to the message
         :param severity: The severity level of the message.
@@ -421,11 +423,14 @@ class LintCheck(metaclass=LintCheckMeta):
         # We must adapt the section by prepending a slash
         if section and not section.startswith("/"):
             section = "/" + section
-        # This should only happen during testing
-        if not self.recipe_path:
-            self.recipe_path = Path("meta.yaml")
-        fname = self.recipe_path.relative_to(self.recipe_path.parent.parent.parent)
-        fname = str(fname)
+        if fname is None:
+            if not self.recipe_path:
+                # This should only happen during testing
+                self.recipe_path = Path("meta.yaml")
+            fname = self.recipe_path.relative_to(self.recipe_path.parent.parent.parent)
+            fname = str(fname)
+        else:
+            fname = str(fname)
         message = self.make_message(
             *args,
             recipe=self.recipe,

--- a/anaconda_linter/lint/__init__.py
+++ b/anaconda_linter/lint/__init__.py
@@ -877,9 +877,9 @@ class Linter:
                     if fix and unrendered_recipe.is_modified():
                         with open(write_path, "w", encoding="utf-8") as fdes:
                             fdes.write(unrendered_recipe.render())
-        except Exception as e:  # pylint: disable=broad-exception-caught
+        except Exception:  # pylint: disable=broad-exception-caught
             recipe = _recipe.Recipe(recipe_name)
-            return [linter_failure.make_message(recipe=recipe, fname=recipe_name, title_in=e.message)]
+            return [linter_failure.make_message(recipe=recipe, fname=recipe_name)]
 
         return list(messages)
 

--- a/anaconda_linter/lint/__init__.py
+++ b/anaconda_linter/lint/__init__.py
@@ -810,8 +810,9 @@ class Linter:
         # Gather variants for specified subdir
         # As a stopgap, this process outputs a tuple per variant with
         # variants and variant info using Percy
-        # TODO: replace with CRM variants generation
+        # TODO: replace with CRM variants generation -> CRM #399
         # TODO: track recipe variants (python version, arch, etc.) all the way to error reporting to ease fixing
+        # anaconda-linter #403
         recipe_variants: list[tuple] = []
         try:
             meta_yaml = Path(recipe_name) / "meta.yaml"

--- a/anaconda_linter/lint/__init__.py
+++ b/anaconda_linter/lint/__init__.py
@@ -312,7 +312,7 @@ class LintCheck(metaclass=LintCheckMeta):
 
         # Run general checks with CRM
         try:
-            self.check_recipe_crm(recipe_name, arch_name, self.recipe)
+            self.check_recipe(recipe_name, arch_name, self.recipe)
         except Exception:  # pylint: disable=broad-exception-caught
             message = self.make_message(
                 recipe=self.recipe,
@@ -327,7 +327,7 @@ class LintCheck(metaclass=LintCheckMeta):
 
         # Run general checks with Percy
         try:
-            self.check_recipe(self.percy_recipe)
+            self.check_recipe_legacy(self.percy_recipe)
         except Exception:  # pylint: disable=broad-exception-caught
             message = self.make_message(
                 recipe=self.percy_recipe,
@@ -358,7 +358,7 @@ class LintCheck(metaclass=LintCheckMeta):
         :param section: Path to the section. Can be `source` or `source/0` (1,2,3...).
         """
 
-    def check_recipe(self, recipe: _recipe.Recipe) -> None:
+    def check_recipe_legacy(self, recipe: _recipe.Recipe) -> None:
         """
         Execute check on recipe
 
@@ -368,7 +368,7 @@ class LintCheck(metaclass=LintCheckMeta):
         :param recipe: The recipe under test.
         """
 
-    def check_recipe_crm(self, recipe_name: str, arch_name: str, recipe: RecipeReaderDeps) -> None:
+    def check_recipe(self, recipe_name: str, arch_name: str, recipe: RecipeReaderDeps) -> None:
         """
         Execute check on recipe using CRM
 

--- a/anaconda_linter/lint/__init__.py
+++ b/anaconda_linter/lint/__init__.py
@@ -801,7 +801,8 @@ class Linter:
             print(f"Linting subdir:{arch_name} recipe:{recipe_name}")
 
         # Gather variants for specified subdir
-        # As a compatibility stopgap, this process outputs a dict of variant_id -> recipe_dump
+        # As a stopgap, this process outputs a tuple with
+        # variants and variant info using Percy
         # TODO: replace with CRM variants generation
         # TODO: track recipe variants (python version, arch, etc.) all the way to error reporting to ease fixing
         recipe_variants: list[tuple[dict, RecipeReaderDeps]] = []

--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -1047,7 +1047,10 @@ class no_git_on_windows(LintCheck):
             # Attempt to filter-out false-positives
             if "/requirements" not in path:
                 continue
-            self.unrendered_recipe.add_selector(path, "[not win]", SelectorConflictMode.AND)
+            try:
+                self.unrendered_recipe.add_selector(path, "[not win]", SelectorConflictMode.AND)
+            except KeyError:
+                return False
         return True
 
 

--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -366,7 +366,6 @@ class build_tools_must_be_in_build(LintCheck):
             if tool.startswith("msys2-") or tool.startswith("m2-") or tool in BUILD_TOOLS:
                 for path in dep["paths"]:
                     o = -1 if not path.startswith("outputs") else int(path.split("/")[1])
-                    print("")
                     self.message(tool, severity=Severity.WARNING, section=path, output=o)
 
 

--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -590,14 +590,15 @@ class cython_needs_compiler(LintCheck):
 
     def check_recipe(self, recipe_name: str, arch_name: str, recipe: RecipeReaderDeps) -> None:
         for dependency_path in recipe.get_dependency_paths():
-            if recipe.get_value(dependency_path) == "cython":
-                requirements_path = "/".join(dependency_path.split("/")[:-2])
-                build_deps = recipe.get_value(f"{requirements_path}/build", None)
-                if not build_deps or not isinstance(build_deps, list):
-                    self.message(section=dependency_path)
-                    continue
-                if "compiler_c" not in build_deps:
-                    self.message(section=dependency_path)
+            if not recipe.get_value(dependency_path) == "cython":
+                continue
+            requirements_path = "/".join(dependency_path.split("/")[:-2])
+            build_deps = recipe.get_value(f"{requirements_path}/build", None)
+            if not build_deps or not isinstance(build_deps, list):
+                self.message(section=dependency_path)
+                continue
+            if "compiler_c" not in build_deps:
+                self.message(section=dependency_path)
 
 
 class avoid_noarch(LintCheck):

--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -294,6 +294,15 @@ class should_use_stdlib(LintCheck):
 
     """
 
+    # NOTE: This is a temporary fix since LintCheck.check_deps() is deprecated
+    def _check_deps(self, deps) -> None:
+        """
+        Checks for manual use of the `sysroot`, `macosx_deployment_target` or `vs` packages in recipes.
+        """
+        for stdlib in STDLIBS:
+            for location in deps.get(stdlib, {}).get("paths", []):
+                self.message(section=location)
+
     def check_recipe(self, recipe: Recipe) -> None:
         """
         Ensures a {{ stdlib('c') }} macro is used in any recipe using a compiler.
@@ -314,13 +323,7 @@ class should_use_stdlib(LintCheck):
                     # Output has a compiler but is missing a stdlib dependency.
                     self.message(section=compiler_dep.path)
 
-    def check_deps(self, deps) -> None:
-        """
-        Checks for manual use of the `sysroot`, `macosx_deployment_target` or `vs` packages in recipes.
-        """
-        for stdlib in STDLIBS:
-            for location in deps.get(stdlib, {}).get("paths", []):
-                self.message(section=location)
+        self._check_deps(_utils.get_deps_dict(recipe))
 
 
 class stdlib_must_be_in_build(LintCheck):
@@ -332,7 +335,8 @@ class stdlib_must_be_in_build(LintCheck):
 
     """
 
-    def check_deps(self, deps) -> None:
+    # NOTE: This is a temporary fix since LintCheck.check_deps() is deprecated
+    def _check_deps(self, deps) -> None:
         for dep in deps:
             for stdlib in STDLIBS:
                 if not dep.startswith(stdlib):
@@ -341,6 +345,9 @@ class stdlib_must_be_in_build(LintCheck):
                 for section in deps[dep]["paths"]:
                     if "run" in section or "host" in section:
                         self.message(section=section)
+
+    def check_recipe(self, recipe: Recipe) -> None:
+        self._check_deps(_utils.get_deps_dict(recipe))
 
 
 class build_tools_must_be_in_build(LintCheck):

--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -631,24 +631,23 @@ class patch_unnecessary(LintCheck):
           - msys2-patch
     """
 
-    def check_recipe(self, recipe: Recipe) -> None:
-        recipe_reader = RecipeReaderDeps(recipe.dump())
-        all_deps = recipe_reader.get_all_dependencies()
+    def check_recipe_crm(self, recipe_name: str, arch_name: str, recipe: RecipeReaderDeps) -> None:
+        all_deps = recipe.get_all_dependencies()
         for package in all_deps:
             for dep in all_deps[package]:
                 if dep.data.name in ["patch", "msys2-patch", "m2-patch"]:
-                    self.message(section=dep.path, data=recipe)
+                    self.message(fname=recipe_name, section=dep.path)
                     return
 
-    def fix(self, message, data) -> bool:
-        # remove patch/msys2-patch/m2-patch from the recipe
-        recipe: Recipe = data
-        try:
-            return recipe.patch_with_parser(
-                lambda parser: _utils.remove_deps_by_name_crm(parser, {"patch", "msys2-patch", "m2-patch"}),
-            )
-        except ValueError:
-            return False
+    # def fix(self, message, data) -> bool:
+    #     # remove patch/msys2-patch/m2-patch from the recipe
+    #     recipe: Recipe = data
+    #     try:
+    #         return recipe.patch_with_parser(
+    #             lambda parser: _utils.remove_deps_by_name_crm(parser, {"patch", "msys2-patch", "m2-patch"}),
+    #         )
+    #     except ValueError:
+    #         return False
 
 
 class has_run_test_and_commands(LintCheck):

--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -464,7 +464,7 @@ class uses_setup_py(LintCheck):
                                         output = int(package.path_prefix.split("/")[1])
                                     else:
                                         output = -1
-                                    self.message(output=output)
+                                    self.message(fname=build_file, output=output)
                 except (FileNotFoundError, TypeError):
                     pass
 
@@ -538,7 +538,7 @@ class pip_install_args(LintCheck):
                                         output = int(package.path_prefix.split("/")[1])
                                     else:
                                         output = -1
-                                    self.message(output=output)
+                                    self.message(fname=build_file, output=output)
                 except (FileNotFoundError, TypeError):
                     pass
 
@@ -808,7 +808,7 @@ class missing_pip_check(LintCheck):
                 for line in test_file:
                     if "pip check" in line:
                         return
-        self.message(data=(recipe, package))
+        self.message(fname=file, data=(recipe, package))
 
     def check_recipe(self, recipe: Recipe) -> None:
         is_pypi = is_pypi_source(recipe)

--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -970,6 +970,7 @@ class no_git_on_windows(LintCheck):
             if recipe.get_value(dependency_path) == "git":
                 self.message(section=dependency_path)
 
+    # TODO: Re-enable this when we have a way to fix the recipe
     # def fix(self, message, data) -> bool:
     #     # NOTE: The path found in `check_deps()` is a post-selector-rendering
     #     # path to the dependency. So in order to change the recipe file, we need

--- a/anaconda_linter/lint/check_completeness.py
+++ b/anaconda_linter/lint/check_completeness.py
@@ -21,7 +21,7 @@ class missing_section(LintCheck):
     Please add this section to the recipe or output
     """
 
-    def check_recipe(self, recipe: Recipe) -> None:
+    def check_recipe_legacy(self, recipe: Recipe) -> None:
         global_sections = (
             "package",
             "build",
@@ -52,7 +52,7 @@ class missing_build_number(LintCheck):
             number: 0
     """
 
-    def check_recipe(self, recipe: Recipe) -> None:
+    def check_recipe_legacy(self, recipe: Recipe) -> None:
         if not recipe.get("build/number", ""):
             self.message(section="build")
 
@@ -67,7 +67,7 @@ class missing_package_name(LintCheck):
             name: <package name>
     """
 
-    def check_recipe(self, recipe: Recipe) -> None:
+    def check_recipe_legacy(self, recipe: Recipe) -> None:
         if not recipe.get("package/name", ""):
             self.message(section="package")
 
@@ -82,7 +82,7 @@ class missing_package_version(LintCheck):
             version: <package version>
     """
 
-    def check_recipe(self, recipe: Recipe) -> None:
+    def check_recipe_legacy(self, recipe: Recipe) -> None:
         if not recipe.get("package/version", ""):
             self.message(section="package")
 
@@ -98,7 +98,7 @@ class missing_home(LintCheck):
 
     """
 
-    def check_recipe(self, recipe: Recipe) -> None:
+    def check_recipe_legacy(self, recipe: Recipe) -> None:
         if not recipe.get("about/home", ""):
             self.message(section="about")
 
@@ -114,7 +114,7 @@ class missing_summary(LintCheck):
 
     """
 
-    def check_recipe(self, recipe: Recipe) -> None:
+    def check_recipe_legacy(self, recipe: Recipe) -> None:
         if not recipe.get("about/summary", ""):
             self.message(section="about")
 
@@ -130,7 +130,7 @@ class missing_license(LintCheck):
 
     """
 
-    def check_recipe(self, recipe: Recipe) -> None:
+    def check_recipe_legacy(self, recipe: Recipe) -> None:
         if not recipe.get("about/license", ""):
             self.message(section="about")
 
@@ -157,7 +157,7 @@ class missing_license_file(LintCheck):
 
     """
 
-    def check_recipe(self, recipe: Recipe) -> None:
+    def check_recipe_legacy(self, recipe: Recipe) -> None:
         if not recipe.get("about/license_file", "") and not recipe.get("about/license_url", ""):
             self.message(section="about", severity=Severity.WARNING)
 
@@ -169,7 +169,7 @@ class license_file_overspecified(LintCheck):
     Please remove license_url.
     """
 
-    def check_recipe(self, recipe: Recipe) -> None:
+    def check_recipe_legacy(self, recipe: Recipe) -> None:
         if recipe.get("about/license_file", "") and recipe.get("about/license_url", ""):
             self.message(section="about", severity=Severity.WARNING, data=recipe)
 
@@ -190,7 +190,7 @@ class missing_license_family(LintCheck):
 
     """
 
-    def check_recipe(self, recipe: Recipe) -> None:
+    def check_recipe_legacy(self, recipe: Recipe) -> None:
         if not recipe.get("about/license_family", ""):
             self.message(section="about")
 
@@ -206,7 +206,7 @@ class invalid_license_family(LintCheck):
 
     """
 
-    def check_recipe(self, recipe: Recipe) -> None:
+    def check_recipe_legacy(self, recipe: Recipe) -> None:
         license_family = recipe.get("about/license_family", "").lower()
         if license_family:
             if license_family == "none":
@@ -256,7 +256,7 @@ class missing_tests(LintCheck):
         else:
             self.message(section=output, output=o)
 
-    def check_recipe(self, recipe: Recipe) -> None:
+    def check_recipe_legacy(self, recipe: Recipe) -> None:
         if outputs := recipe.get("outputs", None):
             for o in range(len(outputs)):
                 if not recipe.get(f"outputs/{o}/test/script", ""):
@@ -345,7 +345,7 @@ class missing_documentation(LintCheck):
 
     """
 
-    def check_recipe(self, recipe: Recipe) -> None:
+    def check_recipe_legacy(self, recipe: Recipe) -> None:
         if not recipe.get("about/doc_url", "") and not recipe.get("about/doc_source_url", ""):
             self.message(section="about")
 
@@ -358,7 +358,7 @@ class documentation_overspecified(LintCheck):
 
     """
 
-    def check_recipe(self, recipe: Recipe) -> None:
+    def check_recipe_legacy(self, recipe: Recipe) -> None:
         if recipe.get("about/doc_url", "") and recipe.get("about/doc_source_url", ""):
             self.message(section="about", severity=Severity.WARNING)
 
@@ -371,7 +371,7 @@ class documentation_specifies_language(LintCheck):
 
     """
 
-    def check_recipe(self, recipe: Recipe) -> None:
+    def check_recipe_legacy(self, recipe: Recipe) -> None:
         lang_url = re.compile(r"readthedocs.io\/[a-z]{2,3}/latest")  # assume ISO639-1 or similar language code
         if recipe.get("about/doc_url", "") and lang_url.search(recipe.get("about/doc_url", "")):
             self.message(section="about/doc_url", severity=Severity.WARNING)
@@ -388,7 +388,7 @@ class missing_dev_url(LintCheck):
 
     """
 
-    def check_recipe(self, recipe: Recipe) -> None:
+    def check_recipe_legacy(self, recipe: Recipe) -> None:
         if not recipe.get("about/dev_url", ""):
             self.message(section="about")
 
@@ -404,7 +404,7 @@ class missing_description(LintCheck):
 
     """
 
-    def check_recipe(self, recipe: Recipe) -> None:
+    def check_recipe_legacy(self, recipe: Recipe) -> None:
         if not recipe.get("about/description", ""):
             self.message(section="about", severity=Severity.WARNING)
 
@@ -426,7 +426,7 @@ class wrong_output_script_key(LintCheck):
             script: build_script.sh
     """
 
-    def check_recipe(self, recipe: Recipe) -> None:
+    def check_recipe_legacy(self, recipe: Recipe) -> None:
         for package in recipe.packages.values():
             if package.path_prefix.startswith("outputs"):
                 if recipe.get(f"{package.path_prefix}build/script", None):

--- a/anaconda_linter/lint/check_completeness.py
+++ b/anaconda_linter/lint/check_completeness.py
@@ -9,11 +9,9 @@ import os
 import re
 
 import conda_build.license_family
-from percy.render.recipe import Recipe
+from percy.render.recipe import OpMode, Recipe
 
 from anaconda_linter.lint import LintCheck, Severity
-
-# from percy.render.recipe import OpMode
 
 
 class missing_section(LintCheck):
@@ -175,11 +173,10 @@ class license_file_overspecified(LintCheck):
         if recipe.get("about/license_file", "") and recipe.get("about/license_url", ""):
             self.message(section="about", severity=Severity.WARNING, data=recipe)
 
-    # TODO: Re-enable this fix once auto-fixing is enabled
-    # def fix(self, message, data) -> bool:
-    #     recipe = data
-    #     op = [{"op": "remove", "path": "/about/license_url"}]
-    #     return recipe.patch(op, op_mode=OpMode.PARSE_TREE)
+    def fix(self, message, data) -> bool:
+        recipe = data
+        op = [{"op": "remove", "path": "/about/license_url"}]
+        return recipe.patch(op, op_mode=OpMode.PARSE_TREE)
 
 
 class missing_license_family(LintCheck):

--- a/anaconda_linter/lint/check_completeness.py
+++ b/anaconda_linter/lint/check_completeness.py
@@ -9,6 +9,7 @@ import os
 import re
 
 import conda_build.license_family
+from conda_recipe_manager.parser.recipe_reader_deps import RecipeReaderDeps
 from percy.render.recipe import OpMode, Recipe
 
 from anaconda_linter.lint import LintCheck, Severity
@@ -279,14 +280,13 @@ class missing_hash(LintCheck):
 
     """
 
-    checksum_names = ["sha256"]
-
     exempt_types = ["git_url", "path"]
 
-    def check_source(self, source, section) -> None:
-        if not any(source.get(typ, None) for typ in self.exempt_types) and not any(
-            source.get(chk, None) for chk in self.checksum_names
-        ):
+    def check_source(self, source: dict, section: str) -> None:
+        for type in self.exempt_types:
+            if type in source:
+                return
+        if "sha256" not in source:
             self.message(section=section)
 
 

--- a/anaconda_linter/lint/check_completeness.py
+++ b/anaconda_linter/lint/check_completeness.py
@@ -9,10 +9,11 @@ import os
 import re
 
 import conda_build.license_family
-from conda_recipe_manager.parser.recipe_reader_deps import RecipeReaderDeps
-from percy.render.recipe import OpMode, Recipe
+from percy.render.recipe import Recipe
 
 from anaconda_linter.lint import LintCheck, Severity
+
+# from percy.render.recipe import OpMode
 
 
 class missing_section(LintCheck):
@@ -174,10 +175,11 @@ class license_file_overspecified(LintCheck):
         if recipe.get("about/license_file", "") and recipe.get("about/license_url", ""):
             self.message(section="about", severity=Severity.WARNING, data=recipe)
 
-    def fix(self, message, data) -> bool:
-        recipe = data
-        op = [{"op": "remove", "path": "/about/license_url"}]
-        return recipe.patch(op, op_mode=OpMode.PARSE_TREE)
+    # TODO: Re-enable this fix once auto-fixing is enabled
+    # def fix(self, message, data) -> bool:
+    #     recipe = data
+    #     op = [{"op": "remove", "path": "/about/license_url"}]
+    #     return recipe.patch(op, op_mode=OpMode.PARSE_TREE)
 
 
 class missing_license_family(LintCheck):
@@ -283,8 +285,8 @@ class missing_hash(LintCheck):
     exempt_types = ["git_url", "path"]
 
     def check_source(self, source: dict, section: str) -> None:
-        for type in self.exempt_types:
-            if type in source:
+        for ex_type in self.exempt_types:
+            if ex_type in source:
                 return
         if "sha256" not in source:
             self.message(section=section)

--- a/anaconda_linter/lint/check_multi_output.py
+++ b/anaconda_linter/lint/check_multi_output.py
@@ -18,7 +18,7 @@ class output_missing_name(LintCheck):
       - name: <output name>
     """
 
-    def check_recipe(self, recipe) -> None:
+    def check_recipe_legacy(self, recipe) -> None:
         if outputs := recipe.get("outputs", None):
             output_names = [recipe.get(f"outputs/{n}/name", None) for n in range(len(outputs))]
             for n, name in enumerate(output_names):
@@ -34,7 +34,7 @@ class outputs_not_unique(LintCheck):
     and are not the same as the package name.
     """
 
-    def check_recipe(self, recipe) -> None:
+    def check_recipe_legacy(self, recipe) -> None:
         if outputs := recipe.get("outputs", None):
             unique_names = [recipe.get("package/name")]
             output_names = [recipe.get(f"outputs/{n}/name", "") for n in range(len(outputs))]
@@ -52,7 +52,7 @@ class no_global_test(LintCheck):
     Tests must be added to each individual output.
     """
 
-    def check_recipe(self, recipe) -> None:
+    def check_recipe_legacy(self, recipe) -> None:
         if recipe.get("outputs", None) and recipe.get("test", None):
             self.message(severity=Severity.WARNING)
 
@@ -64,7 +64,7 @@ class output_missing_script(LintCheck):
     Every output must have either a filename or a command in the script field.
     """
 
-    def check_recipe(self, recipe) -> None:
+    def check_recipe_legacy(self, recipe) -> None:
         # May not need scripts if pin_subpackage is used.
         # Pinned subpackages are expanded to their names.
         outputs = recipe.get("outputs", [])
@@ -84,7 +84,7 @@ class output_script_name_default(LintCheck):
     Output should not use default script names build.sh/bld.bat.
     """
 
-    def check_recipe(self, recipe) -> None:
+    def check_recipe_legacy(self, recipe) -> None:
         default_scripts = ("build.sh", "bld.bat")
         for o in range(len(recipe.get("outputs", []))):
             if recipe.get(f"outputs/{o}/script", "") in default_scripts:

--- a/anaconda_linter/lint/check_spdx.py
+++ b/anaconda_linter/lint/check_spdx.py
@@ -29,7 +29,7 @@ class incorrect_license(LintCheck):
 
     """
 
-    def check_recipe(self, recipe) -> None:
+    def check_recipe_legacy(self, recipe) -> None:
         licensing = license_expression.Licensing()
         license = recipe.get("about/license", "")  # pylint: disable=redefined-builtin
         parsed_exceptions = []

--- a/anaconda_linter/lint/check_syntax.py
+++ b/anaconda_linter/lint/check_syntax.py
@@ -21,7 +21,7 @@ class version_constraints_missing_whitespace(LintCheck):
 
     """
 
-    def check_recipe(self, recipe) -> None:
+    def check_recipe_legacy(self, recipe) -> None:
         check_paths = []
         for section in ("build", "run", "host"):
             check_paths.append(f"requirements/{section}")

--- a/anaconda_linter/lint/check_syntax.py
+++ b/anaconda_linter/lint/check_syntax.py
@@ -46,14 +46,14 @@ class version_constraints_missing_whitespace(LintCheck):
         check_paths = []
         for section in ("build", "run", "host"):
             check_paths.append(f"requirements/{section}")
-        if outputs := self.recipe.get("outputs", None):
+        if outputs := self.percy_recipe.get("outputs", None):
             for n in range(len(outputs)):
                 for section in ("build", "run", "host"):
                     check_paths.append(f"outputs/{n}/requirements/{section}")
 
         constraints = re.compile("(.*?)([!<=>].*)")
         for path in check_paths:
-            for spec in self.recipe.get(path, []):
+            for spec in self.percy_recipe.get(path, []):
                 has_constraints = constraints.search(spec)
                 if has_constraints:
                     # The second condition is a fallback.
@@ -61,5 +61,5 @@ class version_constraints_missing_whitespace(LintCheck):
                     space_separated = has_constraints[1].endswith(" ") or " " in has_constraints[0]
                     if not space_separated:
                         dep, ver = has_constraints.groups()
-                        self.recipe.replace(spec, f"{dep} {ver}", within="requirements")
+                        self.percy_recipe.replace(spec, f"{dep} {ver}", within="requirements")
         return True

--- a/anaconda_linter/lint/check_url.py
+++ b/anaconda_linter/lint/check_url.py
@@ -35,7 +35,7 @@ class invalid_url(LintCheck):
         else:
             _verify_url(url)
 
-    def check_recipe(self, recipe) -> None:
+    def check_recipe_legacy(self, recipe) -> None:
         url_fields: list[str] = [
             "about/home",
             "about/doc_url",
@@ -83,7 +83,7 @@ class http_url(LintCheck):
         else:
             self._check_url(url, section)
 
-    def check_recipe(self, recipe) -> None:
+    def check_recipe_legacy(self, recipe) -> None:
         url_fields = [
             "about/home",
             "about/doc_url",

--- a/anaconda_linter/lint_names.md
+++ b/anaconda_linter/lint_names.md
@@ -6,7 +6,7 @@ compilers_must_be_in_build
 
 conda_render_failure
 
-cython_must_be_in_host
+python_build_tools_in_host
 
 cython_needs_compiler
 

--- a/anaconda_linter/run.py
+++ b/anaconda_linter/run.py
@@ -178,7 +178,7 @@ def execute_linter(  # pylint: disable=too-many-positional-arguments
     overall_result = 0
     # TODO evaluate this: Not all of our rules require checking against variants now that we have the parser in percy.
     for subdir in subdirs:
-        result = linter.lint(recipes, subdir, variant_config_files, exclusive_config_files, fix=fix_flag)
+        result = linter.lint(recipes, subdir, variant_config_files, exclusive_config_files, fix_flag)
         if result > overall_result:  # pylint: disable=consider-using-max-builtin
             overall_result = result
         messages = messages | set(linter.get_messages())

--- a/anaconda_linter/run.py
+++ b/anaconda_linter/run.py
@@ -177,8 +177,9 @@ def execute_linter(  # pylint: disable=too-many-positional-arguments
     messages = set()
     overall_result = 0
     # TODO evaluate this: Not all of our rules require checking against variants now that we have the parser in percy.
+    # TODO evaluate when the linter must be run on each variant, and how to handle the auto-fixing. For now, auto-fixing is disabled.
     for subdir in subdirs:
-        result = linter.lint(recipes, subdir, variant_config_files, exclusive_config_files, fix_flag)
+        result = linter.lint(recipes, subdir, variant_config_files, exclusive_config_files, fix=False)
         if result > overall_result:  # pylint: disable=consider-using-max-builtin
             overall_result = result
         messages = messages | set(linter.get_messages())

--- a/anaconda_linter/run.py
+++ b/anaconda_linter/run.py
@@ -140,7 +140,7 @@ def execute_linter(  # pylint: disable=too-many-positional-arguments
     exclusive_config_files: Optional[list[str]] = None,
     subdirs: Optional[list[str]] = None,
     severity: lint.Severity = lint.SEVERITY_MIN_DEFAULT,
-    fix_flag: bool = False,
+    fix_flag: bool = False,  # pylint: disable=unused-argument
     verbose_flag: bool = False,
 ) -> tuple[ReturnCode, str]:
     """
@@ -177,7 +177,8 @@ def execute_linter(  # pylint: disable=too-many-positional-arguments
     messages = set()
     overall_result = 0
     # TODO evaluate this: Not all of our rules require checking against variants now that we have the parser in percy.
-    # TODO evaluate when the linter must be run on each variant, and how to handle the auto-fixing. For now, auto-fixing is disabled.
+    # TODO evaluate when the linter must be run on each variant,
+    # and how to handle the auto-fixing. For now, auto-fixing is disabled.
     for subdir in subdirs:
         result = linter.lint(recipes, subdir, variant_config_files, exclusive_config_files, fix=False)
         if result > overall_result:  # pylint: disable=consider-using-max-builtin

--- a/anaconda_linter/run.py
+++ b/anaconda_linter/run.py
@@ -177,8 +177,6 @@ def execute_linter(  # pylint: disable=too-many-positional-arguments
     messages = set()
     overall_result = 0
     # TODO evaluate this: Not all of our rules require checking against variants now that we have the parser in percy.
-    # TODO evaluate when the linter must be run on each variant,
-    # and how to handle the auto-fixing. For now, auto-fixing is disabled.
     for subdir in subdirs:
         result = linter.lint(recipes, subdir, variant_config_files, exclusive_config_files, fix=fix_flag)
         if result > overall_result:  # pylint: disable=consider-using-max-builtin

--- a/anaconda_linter/run.py
+++ b/anaconda_linter/run.py
@@ -140,7 +140,7 @@ def execute_linter(  # pylint: disable=too-many-positional-arguments
     exclusive_config_files: Optional[list[str]] = None,
     subdirs: Optional[list[str]] = None,
     severity: lint.Severity = lint.SEVERITY_MIN_DEFAULT,
-    fix_flag: bool = False,  # pylint: disable=unused-argument
+    fix_flag: bool = False,
     verbose_flag: bool = False,
 ) -> tuple[ReturnCode, str]:
     """
@@ -180,7 +180,7 @@ def execute_linter(  # pylint: disable=too-many-positional-arguments
     # TODO evaluate when the linter must be run on each variant,
     # and how to handle the auto-fixing. For now, auto-fixing is disabled.
     for subdir in subdirs:
-        result = linter.lint(recipes, subdir, variant_config_files, exclusive_config_files, fix=False)
+        result = linter.lint(recipes, subdir, variant_config_files, exclusive_config_files, fix=fix_flag)
         if result > overall_result:  # pylint: disable=consider-using-max-builtin
             overall_result = result
         messages = messages | set(linter.get_messages())

--- a/environment.yaml
+++ b/environment.yaml
@@ -15,7 +15,7 @@ dependencies:
   - license-expression
   - jinja2
   - conda-build
-  - conda-recipe-manager >=0.6.1
+  - conda-recipe-manager >=0.6.2
   - jsonschema
   - networkx
   - requests

--- a/environment.yaml
+++ b/environment.yaml
@@ -15,7 +15,7 @@ dependencies:
   - license-expression
   - jinja2
   - conda-build
-  - conda-recipe-manager
+  - conda-recipe-manager >=0.6.1
   - jsonschema
   - networkx
   - requests

--- a/environment.yaml
+++ b/environment.yaml
@@ -10,7 +10,6 @@ dependencies:
   - make
   # run
   - distro-tooling::percy >=0.2.5
-  - distro-tooling::anaconda-packaging-utils
   - ruamel.yaml
   - license-expression
   - jinja2

--- a/environment_dev_crm.yaml
+++ b/environment_dev_crm.yaml
@@ -1,0 +1,37 @@
+name: anaconda-linter
+channels:
+  - defaults
+
+dependencies:
+  - python >=3.11,<3.12
+  # build
+  - setuptools
+  - pip
+  - make
+  # run
+  - distro-tooling::percy >=0.1.5
+  - distro-tooling::anaconda-packaging-utils
+  - ruamel.yaml
+  - license-expression
+  - jinja2
+  - conda-build
+  - jsonschema
+  - networkx
+  - requests
+  # test
+  - pytest
+  - pre-commit
+  # developer tools
+  - black
+  - isort
+  - mypy
+  - pylint
+  - shellcheck
+  # plug ins
+  - pytest-cov
+  - pytest-html
+  - pytest-xdist
+  # scripts
+  - python-dotenv
+  - PyGithub
+  - matplotlib

--- a/environment_dev_crm.yaml
+++ b/environment_dev_crm.yaml
@@ -9,8 +9,7 @@ dependencies:
   - pip
   - make
   # run
-  - distro-tooling::percy >=0.1.5
-  - distro-tooling::anaconda-packaging-utils
+  - distro-tooling::percy >=0.2.5
   - ruamel.yaml
   - license-expression
   - jinja2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,7 +108,7 @@ def check(
     :return: A list containing errors or warnings for the target rule.
     """
     linter_obj, recipe = load_linter_and_recipe(recipe_str, arch, expand_variant)
-    messages = linter_obj.check_instances[check_name].run(recipe=recipe)
+    messages = linter_obj.check_instances[check_name].run(recipe=recipe, arch_name=arch)
     return messages
 
 
@@ -133,14 +133,32 @@ def check_dir(check_name: str, feedstock_dir: str | Path, recipe_str: str, arch:
     if variants:
         # for when a cbc is provided
         (vid, variant) = variants[0]
+        print(" --- variant --- ")
+        print(variant)
+        print(" --- variant --- ")
+        print(" --- vid --- ")
+        print(vid)
+        print(" --- vid --- ")
     else:
         # for when no cbc is provided
         vid = "dummy"
         variant = config[arch]
-    recipe = Recipe.from_file(
+    percy_recipe = Recipe.from_file(
         recipe_fname=str(meta_yaml), variant_id=vid, variant=variant, renderer=RendererType.RUAMEL
     )
-    messages = linter_obj.check_instances[check_name].run(recipe=recipe)
+    print(" --- percy_recipe --- ")
+    print(percy_recipe.get("requirements"))
+    print(" --- percy_recipe --- ")
+    buf = StringIO()
+    yaml = YAML()
+    yaml.indent(mapping=2, sequence=4, offset=2)
+    yaml.dump(percy_recipe.meta, buf)
+    recipe_content = buf.getvalue()
+    recipe = RecipeReaderDeps(recipe_content)
+    print(" --- recipe --- ")
+    print(recipe.render())
+    print(" --- recipe --- ")
+    messages = linter_obj.check_instances[check_name].run(recipe=recipe, arch_name=arch)
     return messages
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,7 +64,7 @@ def load_file(file: Path | str) -> str:
 
 def load_linter_and_recipe(
     recipe_str: str, arch: str = "linux-64", expand_variant: Optional[Variant] = None
-) -> tuple[Linter, RecipeReaderDeps]:
+) -> tuple[Linter, RecipeReaderDeps, RecipeParserDeps, Recipe]:
     """
     Convenience function that loads instantiates linter and recipe objects based on default configurations.
     :param recipe_str:      Recipe file, as a raw string

--- a/tests/lint/test_auto_fix_rules.py
+++ b/tests/lint/test_auto_fix_rules.py
@@ -15,7 +15,6 @@ import pytest
 from conftest import assert_on_auto_fix
 
 
-# TODO: Re-enable this test once auto-fixing is re-enabled
 # Format: (Check Name, File Suffix, Architecture, Number of Occurrences)
 # Common file suffixes:
 #   - `mo` -> For multi-output test cases

--- a/tests/lint/test_auto_fix_rules.py
+++ b/tests/lint/test_auto_fix_rules.py
@@ -36,7 +36,5 @@ def test_auto_fix_rule(check: str, suffix: str, arch: str):
     :param suffix: File suffix, allowing developers to create multiple test files against a linter check.
     :param arch: Architecture to run the test against.
     """
-    if check == "no_git_on_windows":
-        pytest.xfail("Percy deprecation has broken this feature - patching needs to be fixed")
 
     assert_on_auto_fix(check, suffix, arch)

--- a/tests/lint/test_auto_fix_rules.py
+++ b/tests/lint/test_auto_fix_rules.py
@@ -28,7 +28,6 @@ from conftest import assert_on_auto_fix
         ("patch_unnecessary", "", "linux-64"),
     ],
 )
-@pytest.mark.skip(reason="Percy deprecation has broken this feature - patching needs to be fixed")
 def test_auto_fix_rule(check: str, suffix: str, arch: str):
     """
     Tests auto-fixable rules by passing in a file with the issue and checking the output with an expected file.

--- a/tests/lint/test_auto_fix_rules.py
+++ b/tests/lint/test_auto_fix_rules.py
@@ -15,6 +15,7 @@ import pytest
 from conftest import assert_on_auto_fix
 
 
+# TODO: Re-enable this test once auto-fixing is re-enabled
 # Format: (Check Name, File Suffix, Architecture, Number of Occurrences)
 # Common file suffixes:
 #   - `mo` -> For multi-output test cases
@@ -27,6 +28,7 @@ from conftest import assert_on_auto_fix
         ("patch_unnecessary", "", "linux-64"),
     ],
 )
+@pytest.mark.skip(reason="Percy deprecation has broken this feature - patching needs to be fixed")
 def test_auto_fix_rule(check: str, suffix: str, arch: str):
     """
     Tests auto-fixable rules by passing in a file with the issue and checking the output with an expected file.

--- a/tests/lint/test_build_help.py
+++ b/tests/lint/test_build_help.py
@@ -495,8 +495,6 @@ def test_missing_python_build_tool_url_good_multi(base_yaml: str, tool: str) -> 
     assert len(messages) == 0
 
 
-# TODO: Re-enable once CRM is fixed
-@pytest.mark.skip(reason="CRM Bug")
 def test_missing_python_build_tool_url_bad(base_yaml: str) -> None:
     yaml_str = (
         base_yaml
@@ -620,8 +618,6 @@ def test_missing_python_build_tool_pip_install_good_multi_list(base_yaml: str, t
     assert len(messages) == 0
 
 
-# TODO: Re-enable this test once CRM is fixed
-@pytest.mark.skip(reason="CRM Bug")
 def test_missing_python_build_tool_pip_install_bad(base_yaml: str) -> None:
     yaml_str = (
         base_yaml
@@ -639,8 +635,6 @@ def test_missing_python_build_tool_pip_install_bad(base_yaml: str) -> None:
     assert len(messages) == 1 and "require a python build tool" in messages[0].title
 
 
-# TODO: Re-enable this test once CRM is fixed
-@pytest.mark.skip(reason="CRM Bug")
 def test_missing_python_build_tool_pip_install_bad_list(base_yaml: str) -> None:
     yaml_str = (
         base_yaml
@@ -2583,8 +2577,6 @@ def test_remove_python_pinning_bad_multi(base_yaml: str) -> None:
     assert len(messages) == 4 and all("python deps should not be constrained" in m.title for m in messages)
 
 
-# TODO: Re-enable once CRM is fixed
-@pytest.mark.skip(reason="CRM Bug")
 @pytest.mark.parametrize("arch", ("linux-64", "win-64"))
 def test_no_git_on_windows_good(base_yaml: str, arch: str) -> None:  # pylint: disable=unused-argument
     yaml_str = (

--- a/tests/lint/test_build_help.py
+++ b/tests/lint/test_build_help.py
@@ -510,8 +510,6 @@ def test_missing_python_build_tool_url_bad(base_yaml: str) -> None:
     assert len(messages) == 1 and "require a python build tool" in messages[0].title
 
 
-# TODO: Re-enable once CRM is fixed
-@pytest.mark.skip(reason="CRM Bug")
 def test_missing_python_build_tool_url_bad_multi(base_yaml: str) -> None:
     yaml_str = (
         base_yaml
@@ -653,8 +651,6 @@ def test_missing_python_build_tool_pip_install_bad_list(base_yaml: str) -> None:
     assert len(messages) == 1 and "require a python build tool" in messages[0].title
 
 
-# TODO: Re-enable this test once CRM is fixed
-@pytest.mark.skip(reason="CRM Bug")
 def test_missing_python_build_tool_pip_install_bad_multi(base_yaml: str) -> None:
     yaml_str = (
         base_yaml
@@ -675,8 +671,6 @@ def test_missing_python_build_tool_pip_install_bad_multi(base_yaml: str) -> None
     assert len(messages) == 2 and all("require a python build tool" in msg.title for msg in messages)
 
 
-# TODO: Re-enable this test once CRM is fixed
-@pytest.mark.skip(reason="CRM Bug")
 def test_missing_python_build_tool_pip_install_bad_multi_list(base_yaml: str) -> None:
     yaml_str = (
         base_yaml
@@ -1619,8 +1613,6 @@ def test_missing_imports_or_run_test_py_bad_multi(base_yaml: str) -> None:
     assert len(messages) == 2 and all("Python packages require imports" in msg.title for msg in messages)
 
 
-# TODO: Re-enable this test once CRM is fixed
-@pytest.mark.skip(reason="CRM Bug")
 def test_missing_imports_or_run_test_py_bad_multi_pypi(base_yaml: str) -> None:
     yaml_str = (
         base_yaml
@@ -2589,8 +2581,6 @@ def test_no_git_on_windows_good(base_yaml: str, arch: str) -> None:  # pylint: d
     )
     lint_check = "no_git_on_windows"
     messages = check(lint_check, yaml_str, arch="win-64")
-    for message in messages:
-        print(message.title)
     assert len(messages) == 0
 
 

--- a/tests/lint/test_build_help.py
+++ b/tests/lint/test_build_help.py
@@ -100,6 +100,8 @@ def test_host_section_needs_exact_pinnings_good_cbc(base_yaml: str, recipe_dir: 
     cbc_file.write_text(cbc)
     lint_check = "host_section_needs_exact_pinnings"
     messages = check_dir(lint_check, recipe_dir.parent, yaml_str)
+    for message in messages:
+        print(message.title)
     assert len(messages) == 0
 
 
@@ -344,19 +346,19 @@ def test_build_tools_must_be_in_build_good_multi(base_yaml: str, tool: str) -> N
 
 
 @pytest.mark.parametrize("section", ("host", "run"))
-@pytest.mark.parametrize("tool", BUILD_TOOLS)
-def test_build_tools_must_be_in_build_bad(base_yaml: str, section: str, tool: str) -> None:
+# @pytest.mark.parametrize("tool", BUILD_TOOLS)
+def test_build_tools_must_be_in_build_bad(base_yaml: str, section: str) -> None:
     yaml_str = (
         base_yaml
         + f"""
         requirements:
           {section}:
-            - {tool}
+            - msys2-gcc
         """
     )
     lint_check = "build_tools_must_be_in_build"
     messages = check(lint_check, yaml_str)
-    assert len(messages) == 1 and f"build tool {tool} is not in the build section" in messages[0].title
+    assert len(messages) == 1 and f"build tool msys2-gcc is not in the build section" in messages[0].title
 
 
 @pytest.mark.parametrize("section", ("host", "run"))
@@ -493,6 +495,8 @@ def test_missing_python_build_tool_url_good_multi(base_yaml: str, tool: str) -> 
     assert len(messages) == 0
 
 
+# TODO: Re-enable once CRM is fixed
+@pytest.mark.skip(reason="CRM Bug")
 def test_missing_python_build_tool_url_bad(base_yaml: str) -> None:
     yaml_str = (
         base_yaml
@@ -508,6 +512,8 @@ def test_missing_python_build_tool_url_bad(base_yaml: str) -> None:
     assert len(messages) == 1 and "require a python build tool" in messages[0].title
 
 
+# TODO: Re-enable once CRM is fixed
+@pytest.mark.skip(reason="CRM Bug")
 def test_missing_python_build_tool_url_bad_multi(base_yaml: str) -> None:
     yaml_str = (
         base_yaml
@@ -2567,6 +2573,8 @@ def test_remove_python_pinning_bad_multi(base_yaml: str) -> None:
     assert len(messages) == 4 and all("python deps should not be constrained" in m.title for m in messages)
 
 
+# TODO: Re-enable once CRM is fixed
+@pytest.mark.skip(reason="CRM Bug")
 @pytest.mark.parametrize("arch", ("linux-64", "win-64"))
 def test_no_git_on_windows_good(base_yaml: str, arch: str) -> None:  # pylint: disable=unused-argument
     yaml_str = (
@@ -2579,6 +2587,8 @@ def test_no_git_on_windows_good(base_yaml: str, arch: str) -> None:  # pylint: d
     )
     lint_check = "no_git_on_windows"
     messages = check(lint_check, yaml_str, arch="win-64")
+    for message in messages:
+        print(message.title)
     assert len(messages) == 0
 
 

--- a/tests/lint/test_build_help.py
+++ b/tests/lint/test_build_help.py
@@ -1089,21 +1089,22 @@ def test_pip_install_args_multi_script_missing(base_yaml: str, recipe_dir: Path)
     assert len(messages) == 1 and "should be run with --no-deps and --no-build-isolation" in messages[0].title
 
 
-def test_cython_must_be_in_host_good(base_yaml: str) -> None:
+def test_python_build_tools_in_host_good(base_yaml: str) -> None:
     yaml_str = (
         base_yaml
         + """
         requirements:
           host:
-            - cython
+            - setuptools
+            - pip
         """
     )
-    lint_check = "cython_must_be_in_host"
+    lint_check = "python_build_tools_in_host"
     messages = check(lint_check, yaml_str)
     assert len(messages) == 0
 
 
-def test_cython_must_be_in_host_good_multi(base_yaml: str) -> None:
+def test_python_build_tools_in_host_good_multi(base_yaml: str) -> None:
     yaml_str = (
         base_yaml
         + """
@@ -1111,36 +1112,39 @@ def test_cython_must_be_in_host_good_multi(base_yaml: str) -> None:
           - name: output1
             requirements:
               host:
-                - cython
+                - setuptools
+                - pip
           - name: output2
             requirements:
               host:
-                - cython
+                - setuptools
+                - pip
         """
     )
-    lint_check = "cython_must_be_in_host"
+    lint_check = "python_build_tools_in_host"
     messages = check(lint_check, yaml_str)
     assert len(messages) == 0
 
 
 @pytest.mark.parametrize("section", ["build", "run"])
-def test_cython_must_be_in_host_bad(base_yaml: str, section: str) -> None:
-    lint_check = "cython_must_be_in_host"
+def test_python_build_tools_in_host_bad(base_yaml: str, section: str) -> None:
+    lint_check = "python_build_tools_in_host"
     yaml_str = (
         base_yaml
         + f"""
         requirements:
           {section}:
-            - cython
+            - setuptools
+            - pip
         """
     )
     messages = check(lint_check, yaml_str)
-    assert len(messages) == 1 and "Cython should be" in messages[0].title
+    assert len(messages) == 2 and "Python build tools should be" in messages[0].title
 
 
 @pytest.mark.parametrize("section", ["build", "run"])
-def test_cython_must_be_in_host_bad_multi(base_yaml: str, section: str) -> None:
-    lint_check = "cython_must_be_in_host"
+def test_python_build_tools_in_host_bad_multi(base_yaml: str, section: str) -> None:
+    lint_check = "python_build_tools_in_host"
     yaml_str = (
         base_yaml
         + f"""
@@ -1148,15 +1152,17 @@ def test_cython_must_be_in_host_bad_multi(base_yaml: str, section: str) -> None:
           - name: output1
             requirements:
               {section}:
-                - cython
+                - setuptools
+                - pip
           - name: output2
             requirements:
               {section}:
-                - cython
+                - setuptools
+                - pip
     """
     )
     messages = check(lint_check, yaml_str)
-    assert len(messages) == 2 and all("Cython should be" in msg.title for msg in messages)
+    assert len(messages) == 4 and all("Python build tools should be" in msg.title for msg in messages)
 
 
 def test_cython_needs_compiler_good(base_yaml: str) -> None:

--- a/tests/lint/test_build_help.py
+++ b/tests/lint/test_build_help.py
@@ -83,7 +83,7 @@ def test_host_section_needs_exact_pinnings_good_exception_multi(base_yaml: str, 
     assert len(messages) == 0
 
 
-def test_host_section_needs_exact_pinnings_good_cbc(base_yaml: str, recipe_dir: Path) -> None:
+def test_host_section_needs_exact_pinnings_bad_cbc(base_yaml: str, recipe_dir: Path) -> None:
     yaml_str = (
         base_yaml
         + """
@@ -100,9 +100,7 @@ def test_host_section_needs_exact_pinnings_good_cbc(base_yaml: str, recipe_dir: 
     cbc_file.write_text(cbc)
     lint_check = "host_section_needs_exact_pinnings"
     messages = check_dir(lint_check, recipe_dir.parent, yaml_str)
-    for message in messages:
-        print(message.title)
-    assert len(messages) == 0
+    assert len(messages) == 1 and "Linked libraries host should have exact version pinnings." in messages[0].title
 
 
 def test_host_section_needs_exact_pinnings_good_cbc_jinjavar(base_yaml: str, recipe_dir: Path) -> None:
@@ -125,7 +123,7 @@ def test_host_section_needs_exact_pinnings_good_cbc_jinjavar(base_yaml: str, rec
     assert len(messages) == 0
 
 
-def test_host_section_needs_exact_pinnings_good_cbc_multi(base_yaml: str, recipe_dir: Path) -> None:
+def test_host_section_needs_exact_pinnings_bad_cbc_multi(base_yaml: str, recipe_dir: Path) -> None:
     yaml_str = (
         base_yaml
         + """
@@ -148,7 +146,9 @@ def test_host_section_needs_exact_pinnings_good_cbc_multi(base_yaml: str, recipe
     cbc_file.write_text(cbc)
     lint_check = "host_section_needs_exact_pinnings"
     messages = check_dir(lint_check, recipe_dir.parent, yaml_str)
-    assert len(messages) == 0
+    assert len(messages) == 2 and all(
+        "Linked libraries host should have exact version pinnings." in msg.title for msg in messages
+    )
 
 
 @pytest.mark.parametrize("constraint", ("", ">=0.13", "<0.14", "!=0.13.7"))
@@ -358,7 +358,7 @@ def test_build_tools_must_be_in_build_bad(base_yaml: str, section: str) -> None:
     )
     lint_check = "build_tools_must_be_in_build"
     messages = check(lint_check, yaml_str)
-    assert len(messages) == 1 and f"build tool msys2-gcc is not in the build section" in messages[0].title
+    assert len(messages) == 1 and "build tool msys2-gcc is not in the build section" in messages[0].title
 
 
 @pytest.mark.parametrize("section", ("host", "run"))
@@ -620,6 +620,8 @@ def test_missing_python_build_tool_pip_install_good_multi_list(base_yaml: str, t
     assert len(messages) == 0
 
 
+# TODO: Re-enable this test once CRM is fixed
+@pytest.mark.skip(reason="CRM Bug")
 def test_missing_python_build_tool_pip_install_bad(base_yaml: str) -> None:
     yaml_str = (
         base_yaml
@@ -637,6 +639,8 @@ def test_missing_python_build_tool_pip_install_bad(base_yaml: str) -> None:
     assert len(messages) == 1 and "require a python build tool" in messages[0].title
 
 
+# TODO: Re-enable this test once CRM is fixed
+@pytest.mark.skip(reason="CRM Bug")
 def test_missing_python_build_tool_pip_install_bad_list(base_yaml: str) -> None:
     yaml_str = (
         base_yaml
@@ -655,6 +659,8 @@ def test_missing_python_build_tool_pip_install_bad_list(base_yaml: str) -> None:
     assert len(messages) == 1 and "require a python build tool" in messages[0].title
 
 
+# TODO: Re-enable this test once CRM is fixed
+@pytest.mark.skip(reason="CRM Bug")
 def test_missing_python_build_tool_pip_install_bad_multi(base_yaml: str) -> None:
     yaml_str = (
         base_yaml
@@ -675,6 +681,8 @@ def test_missing_python_build_tool_pip_install_bad_multi(base_yaml: str) -> None
     assert len(messages) == 2 and all("require a python build tool" in msg.title for msg in messages)
 
 
+# TODO: Re-enable this test once CRM is fixed
+@pytest.mark.skip(reason="CRM Bug")
 def test_missing_python_build_tool_pip_install_bad_multi_list(base_yaml: str) -> None:
     yaml_str = (
         base_yaml
@@ -1617,6 +1625,8 @@ def test_missing_imports_or_run_test_py_bad_multi(base_yaml: str) -> None:
     assert len(messages) == 2 and all("Python packages require imports" in msg.title for msg in messages)
 
 
+# TODO: Re-enable this test once CRM is fixed
+@pytest.mark.skip(reason="CRM Bug")
 def test_missing_imports_or_run_test_py_bad_multi_pypi(base_yaml: str) -> None:
     yaml_str = (
         base_yaml

--- a/tests/lint/test_build_help.py
+++ b/tests/lint/test_build_help.py
@@ -484,19 +484,19 @@ def test_build_tools_must_be_in_build_good_multi(base_yaml: str, tool: str) -> N
 
 
 @pytest.mark.parametrize("section", ("host", "run"))
-# @pytest.mark.parametrize("tool", BUILD_TOOLS)
-def test_build_tools_must_be_in_build_bad(base_yaml: str, section: str) -> None:
+@pytest.mark.parametrize("tool", BUILD_TOOLS)
+def test_build_tools_must_be_in_build_bad(base_yaml: str, section: str, tool: str) -> None:
     yaml_str = (
         base_yaml
         + f"""
         requirements:
           {section}:
-            - msys2-gcc
+            - {tool}
         """
     )
     lint_check = "build_tools_must_be_in_build"
     messages = check(lint_check, yaml_str)
-    assert len(messages) == 1 and "build tool msys2-gcc is not in the build section" in messages[0].title
+    assert len(messages) == 1 and f"build tool {tool} is not in the build section" in messages[0].title
 
 
 @pytest.mark.parametrize("section", ("host", "run"))

--- a/tests/lint/test_completeness.py
+++ b/tests/lint/test_completeness.py
@@ -502,7 +502,7 @@ def test_missing_source_bad_type(base_yaml: str) -> None:
 def test_non_url_source_good(base_yaml: str, src_type: str) -> None:  # pylint: disable=unused-argument
     yaml_str = (
         base_yaml
-        + """
+        + f"""
         source:
           {src_type}: https://sqlite.com/2022/sqlite-autoconf-3380500.tar.gz
           md5: 5af07de982ba658fd91a03170c945f99c971f6955bc79df3266544373e39869c

--- a/tests/lint/test_multi_output.py
+++ b/tests/lint/test_multi_output.py
@@ -23,6 +23,8 @@ def test_output_missing_name_good(base_yaml: str) -> None:
     assert len(messages) == 0
 
 
+# TODO: Re-enable this test once CRM is fixed
+@pytest.mark.skip(reason="CRM Bug")
 def test_output_missing_name_bad(base_yaml: str) -> None:
     yaml_str = (
         base_yaml
@@ -99,6 +101,8 @@ def test_outputs_not_unique_bad(base_yaml: str) -> None:
     assert len(messages) == 1 and "not unique" in messages[0].title
 
 
+# TODO: Re-enable this test once CRM is fixed
+@pytest.mark.skip(reason="CRM Bug")
 def test_no_global_test_good(base_yaml: str) -> None:
     yaml_str = (
         base_yaml

--- a/tests/lint/test_multi_output.py
+++ b/tests/lint/test_multi_output.py
@@ -101,18 +101,16 @@ def test_outputs_not_unique_bad(base_yaml: str) -> None:
     assert len(messages) == 1 and "not unique" in messages[0].title
 
 
-# TODO: Re-enable this test once CRM is fixed
-@pytest.mark.skip(reason="CRM Bug")
 def test_no_global_test_good(base_yaml: str) -> None:
     yaml_str = (
         base_yaml
         + """
         outputs:
-          - output1:
+          - name: output1
             test:
               import:
                 module1
-          - output2:
+          - name: output2
             test:
               import:
                 module2

--- a/tests/lint/test_multi_output.py
+++ b/tests/lint/test_multi_output.py
@@ -23,8 +23,6 @@ def test_output_missing_name_good(base_yaml: str) -> None:
     assert len(messages) == 0
 
 
-# TODO: Re-enable this test once CRM is fixed
-@pytest.mark.skip(reason="CRM Bug")
 def test_output_missing_name_bad(base_yaml: str) -> None:
     yaml_str = (
         base_yaml

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -297,6 +297,7 @@ def test_get_report_error() -> None:
             severity=Severity.WARNING,
             recipe=None,
             fname="fake_feedstock/recipe/meta.yaml",
+            section="/about/license",
             check="dummy_warning",
             title="Warning message 1",
         ),
@@ -304,6 +305,7 @@ def test_get_report_error() -> None:
             severity=Severity.ERROR,
             recipe=None,
             fname="fake_feedstock/recipe/meta.yaml",
+            section="/build/number",
             check="dummy_error",
             title="Error message 1",
         ),
@@ -311,6 +313,7 @@ def test_get_report_error() -> None:
             severity=Severity.ERROR,
             recipe=None,
             fname="fake_feedstock/recipe/meta.yaml",
+            section="/outputs/0/name",
             check="dummy_error",
             title="Error message 2",
         ),
@@ -321,10 +324,10 @@ def test_get_report_error() -> None:
     assert report == (
         "The following problems have been found:\n"
         "\n===== WARNINGS =====\n"
-        "- fake_feedstock/recipe/meta.yaml:: dummy_warning: Warning message 1\n"
+        "- fake_feedstock/recipe/meta.yaml:/about/license: dummy_warning: Warning message 1\n"
         "\n===== ERRORS ====="
-        "\n- fake_feedstock/recipe/meta.yaml:: dummy_error: Error message 1\n"
-        "- fake_feedstock/recipe/meta.yaml:: dummy_error: Error message 2\n"
+        "\n- fake_feedstock/recipe/meta.yaml:/build/number: dummy_error: Error message 1\n"
+        "- fake_feedstock/recipe/meta.yaml:/outputs/0/name: dummy_error: Error message 2\n"
         "===== Final Report: =====\n"
         "2 Errors and 1 Warning were found"
     )
@@ -339,6 +342,7 @@ def test_get_report_auto_fixes() -> None:
             severity=Severity.WARNING,
             recipe=None,
             fname="fake_feedstock/recipe/meta.yaml",
+            section="/about/license",
             check="dummy_warning",
             title="Warning message 1",
         ),
@@ -346,6 +350,7 @@ def test_get_report_auto_fixes() -> None:
             severity=Severity.ERROR,
             recipe=None,
             fname="fake_feedstock/recipe/meta.yaml",
+            section="/build/number",
             check="dummy_error",
             title="Error message 1",
         ),
@@ -353,6 +358,7 @@ def test_get_report_auto_fixes() -> None:
             severity=Severity.ERROR,
             recipe=None,
             fname="fake_feedstock/recipe/meta.yaml",
+            section="/outputs/0/name",
             check="auto_fix_1",
             title="Auto message 1",
             auto_fix_state=AutoFixState.FIX_PASSED,
@@ -361,6 +367,7 @@ def test_get_report_auto_fixes() -> None:
             severity=Severity.ERROR,
             recipe=None,
             fname="fake_feedstock/recipe/meta.yaml",
+            section="/outputs/1/requirements/run/0",
             check="dummy_error",
             title="Error message 2",
         ),
@@ -368,6 +375,7 @@ def test_get_report_auto_fixes() -> None:
             severity=Severity.WARNING,
             recipe=None,
             fname="fake_feedstock/recipe/meta.yaml",
+            section="/outputs/1/requirements/run/0",
             check="auto_fix_2",
             title="Auto message 2",
             auto_fix_state=AutoFixState.FIX_PASSED,
@@ -376,6 +384,7 @@ def test_get_report_auto_fixes() -> None:
             severity=Severity.ERROR,
             recipe=None,
             fname="fake_feedstock/recipe/meta.yaml",
+            section="/outputs/1/requirements/host/3",
             check="auto_fix_3",
             title="Auto message 3",
             auto_fix_state=AutoFixState.FIX_FAILED,
@@ -390,11 +399,11 @@ def test_get_report_auto_fixes() -> None:
         "- auto_fix_1\n"
         "- auto_fix_2\n"
         "\n===== WARNINGS =====\n"
-        "- fake_feedstock/recipe/meta.yaml:: dummy_warning: Warning message 1\n"
+        "- fake_feedstock/recipe/meta.yaml:/about/license: dummy_warning: Warning message 1\n"
         "\n===== ERRORS ====="
-        "\n- fake_feedstock/recipe/meta.yaml:: dummy_error: Error message 1\n"
-        "- fake_feedstock/recipe/meta.yaml:: dummy_error: Error message 2\n"
-        "- fake_feedstock/recipe/meta.yaml:: auto_fix_3: Auto message 3\n"
+        "\n- fake_feedstock/recipe/meta.yaml:/build/number: dummy_error: Error message 1\n"
+        "- fake_feedstock/recipe/meta.yaml:/outputs/1/requirements/run/0: dummy_error: Error message 2\n"
+        "- fake_feedstock/recipe/meta.yaml:/outputs/1/requirements/host/3: auto_fix_3: Auto message 3\n"
         "===== Final Report: =====\n"
         "Automatically fixed 2 issues.\n"
         "3 Errors and 1 Warning were found"

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -24,7 +24,7 @@ class DummyInfo(lint.LintCheck):
     Info message
     """
 
-    def check_recipe(self, _) -> None:
+    def check_recipe_legacy(self, _) -> None:
         self.message(severity=Severity.INFO)
 
 
@@ -33,7 +33,7 @@ class DummyWarning(lint.LintCheck):
     Warning message
     """
 
-    def check_recipe(self, _) -> None:
+    def check_recipe_legacy(self, _) -> None:
         self.message(severity=Severity.WARNING)
 
 
@@ -42,7 +42,7 @@ class DummyError(lint.LintCheck):
     Error message
     """
 
-    def check_recipe(self, _) -> None:
+    def check_recipe_legacy(self, _) -> None:
         self.message(severity=Severity.ERROR)
 
 
@@ -51,7 +51,7 @@ class DummyErrorFormat(lint.LintCheck):
     {} message of severity {}
     """
 
-    def check_recipe(self, _) -> None:
+    def check_recipe_legacy(self, _) -> None:
         self.message("Dummy", "ERROR")
 
 

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -5,7 +5,6 @@ Description:    Tests linting infrastructure
 
 from __future__ import annotations
 
-import tempfile
 from pathlib import Path
 from typing import Final
 
@@ -250,6 +249,8 @@ def test_jinja_functions(base_yaml: str, jinja_func: str, expected: bool, recipe
     assert any(str(msg.check) == lint_check for msg in messages) == expected
 
 
+# TODO: Re-enable this test once get_raw_range is implemented outside of Percy
+@pytest.mark.skip(reason="Disabled line-reporting temporarily while we migrate to CRM")
 def test_error_report_line(base_yaml: str) -> None:
     yaml_str = (
         base_yaml
@@ -278,6 +279,8 @@ def test_message_title_format(base_yaml: str) -> None:
     assert len(messages) == 1 and messages[0].title == "Dummy message of severity ERROR"
 
 
+@pytest.mark.skip(reason="Disabled temporarily while we migrate to CRM")
+# TODO: Re-enable this test once fname handling is defined properly
 def test_message_path(base_yaml: str, tmpdir: Path) -> None:
     recipe_directory_short = Path("fake_feedstock/recipe")
     recipe_directory = Path(tmpdir) / recipe_directory_short

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -425,6 +425,5 @@ def test_get_report_no_error() -> None:
             title="Info message",
         )
     ]
-    print(messages)
     report: Final[str] = Linter.get_report(messages)
     assert report == ("All checks OK")


### PR DESCRIPTION
**Description:**

The goal of this PR is to setup `conda-recipe-manager` compatibility within `anaconda-linter`:
- Enable gradual `LintCheck` transition to `conda-recipe-manager` parsing
- Enable easy integration of CRM-based recipe variants generation at a later point
- Minimize required refactoring

**Changes include:**

- Added `dev-crm` to the Makefile to allow for `anaconda-linter` development/testing using arbitrary unreleased work from `conda-recipe-manager`.
- Moved to using `RecipeReaderDeps` in the linter as a primary parser, while maintaining compatibility with `Percy`.
- `Percy` is used in variants generation and most rules. This PR allows for an easy progressive transition to `Recipe(Reader/Parser)Deps` in each linter rule.
- Moved from line to section reporting for linter rule reporting.
- Deprecated `LintCheck.check_deps()`, dependencies can be checked in `check_recipe()` directly.
- Updated certain rules along the way.