### PR TITLE
Update Linter Rule: pip_install_args

### DIFF
--- a/anaconda_linter/lint/__init__.py
+++ b/anaconda_linter/lint/__init__.py
@@ -234,7 +234,7 @@ class LintCheckMeta(abc.ABCMeta):
         Creates LintCheck classes
         """
         typ = super().__new__(mcs, name, bases, namespace, **kwargs)
-        if name != "LintCheck":  # don't register base class
+        if name not in {"LintCheck", "ScriptCheck"}:  # don't register base classes
             mcs.registry.append(typ)
         return typ
 
@@ -497,6 +497,92 @@ class LintCheck(metaclass=LintCheckMeta):
             fname=fname,
             section=section,
             canfix=canfix,
+        )
+
+
+class ScriptCheck(LintCheck):
+    """
+    Base class for script checks
+    """
+
+    def _check_line(self, line: str) -> bool:
+        """
+        Check a line for an invalid or obsolete install command
+        """
+
+    def _check_block(self, path: str, value: Any) -> str:
+        """
+        Check a line or a list of lines for an invalid or obsolete install command
+        """
+        if value is None:
+            return ""
+        if isinstance(value, str):
+            if not self._check_line(value):
+                return ""
+            return path
+        for idx, line in enumerate(value):
+            if self._check_line(line):
+                return path + "/" + str(idx)
+
+    def _check_build_sh(self, recipe_dir: Optional[Path], build_script: Any) -> None:
+        """
+        Check a build.sh file for an invalid or obsolete install command
+        """
+        if build_script:
+            if isinstance(build_script, list):
+                return
+            build_file = recipe_dir / build_script
+        else:
+            build_file = recipe_dir / "build.sh"
+        if build_file.exists():
+            with open(build_file, mode="r", encoding="utf-8") as build_sh:
+                for line in build_sh:
+                    if self._check_line(line):
+                        self.message(section=f"build script: {str(build_file)}")
+
+    def _check_build_script(self, recipe_name: str, recipe: RecipeReaderDeps) -> None:
+        """
+        Check the recipe build script, whether it's in the recipe or a standalone file
+        """
+        recipe_dir: Final[Optional[Path]] = Path(recipe_name) if recipe_name else None
+        # Check root level
+        build_script_path: Final[str] = "/build/script"
+        build_script_val = None
+        if recipe.contains_value(build_script_path):
+            build_script_val = recipe.get_value(build_script_path)
+            if build_script_path := self._check_block(build_script_path, build_script_val):
+                self.message(section=build_script_path)
+        if recipe_dir:
+            self._check_build_sh(recipe_dir, build_script_val)
+        # Check outputs
+        for package in recipe.get_package_paths():
+            if package == "/":
+                continue
+            script_path = recipe.append_to_path(package, "/script")
+            output_build_script_path = recipe.append_to_path(package, "/build/script")
+            script_val = None
+            if recipe.contains_value(script_path):
+                script_val = recipe.get_value(script_path)
+                if script_path := self._check_block(script_path, script_val):
+                    self.message(section=script_path)
+            elif recipe.contains_value(output_build_script_path):
+                script_val = recipe.get_value(output_build_script_path)
+                if output_build_script_path := self._check_block(output_build_script_path, script_val):
+                    self.message(section=output_build_script_path)
+            if recipe_dir:
+                self._check_build_sh(recipe_dir, script_val)
+
+    def _fix_script(self, message: LintMessage) -> bool:
+        section = message.section
+        if section.startswith("build script: "):
+            return False
+        recipe = self.unrendered_recipe
+        return recipe.patch(
+            {
+                "op": "replace",
+                "path": section,
+                "value": "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation",
+            }
         )
 
 

--- a/anaconda_linter/lint/__init__.py
+++ b/anaconda_linter/lint/__init__.py
@@ -540,7 +540,7 @@ class ScriptCheck(LintCheck):
                     if self._check_line(line):
                         self.message(section=f"build script: {str(build_file)}")
 
-    def _check_build_script(self, recipe_name: str, recipe: RecipeReaderDeps) -> None:
+    def check_recipe(self, recipe_name: str, arch_name: str, recipe: RecipeReaderDeps) -> None:
         """
         Check the recipe build script, whether it's in the recipe or a standalone file
         """
@@ -572,7 +572,7 @@ class ScriptCheck(LintCheck):
             if recipe_dir:
                 self._check_build_sh(recipe_dir, script_val)
 
-    def _fix_script(self, message: LintMessage) -> bool:
+    def fix(self, message: LintMessage, data: Any) -> bool:
         section = message.section
         if section.startswith("build script: "):
             return False

--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -502,7 +502,7 @@ class pip_install_args(LintCheck):
 
     Please use::
 
-        $PYTHON -m pip install . --no-deps --no-build-isolation
+        {{ PYTHON }} -m pip install . --no-deps --no-build-isolation
 
     """
 

--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import os
 import re
 from pathlib import Path
-from typing import Any, Final, Optional
+from typing import Final
 
 from conda.models.match_spec import MatchSpec
 from conda_recipe_manager.parser.dependency import Dependency, DependencySection
@@ -18,7 +18,7 @@ from conda_recipe_manager.parser.recipe_reader_deps import RecipeReaderDeps
 from percy.render.recipe import Recipe
 
 from anaconda_linter import utils as _utils
-from anaconda_linter.lint import LintCheck, Severity
+from anaconda_linter.lint import LintCheck, ScriptCheck, Severity
 
 # Does not include m2-tools, which should be checked using wild cards.
 BUILD_TOOLS: Final[tuple] = (
@@ -496,7 +496,7 @@ class uses_setup_py(LintCheck):
         return recipe.patch(op)
 
 
-class pip_install_args(LintCheck):
+class pip_install_args(ScriptCheck):
     """
     `pip install` should be run with --no-deps and --no-build-isolation.
 
@@ -506,88 +506,18 @@ class pip_install_args(LintCheck):
 
     """
 
-    @staticmethod
-    def _check_line(line: str) -> bool:
-        """
-        Check a line for a broken call to pip install
-        """
+    def _check_line(self, line: str) -> bool:
         if "pip install" in line:
             required_args = ["--no-deps", "--no-build-isolation"]
             if any(arg not in line for arg in required_args):
                 return True
         return False
 
-    def _check_block(self, path: str, value: Any) -> str:
-        """
-        Check a line or a list of lines for a broken call to pip install
-        """
-        if value is None:
-            return ""
-        if isinstance(value, str):
-            if not self._check_line(value):
-                return ""
-            return path
-        for idx, line in enumerate(value):
-            if self._check_line(line):
-                return path + "/" + str(idx)
-
-    def _check_build_sh(self, recipe_dir: Optional[Path], build_script: Any) -> None:
-        """
-        Check a build.sh file for a broken call to pip install
-        """
-        if build_script:
-            if isinstance(build_script, list):
-                return
-            build_file = recipe_dir / build_script
-        else:
-            build_file = recipe_dir / "build.sh"
-        if build_file.exists():
-            with open(build_file, mode="r", encoding="utf-8") as build_sh:
-                for line in build_sh:
-                    if self._check_line(line):
-                        self.message(section=f"build script: {str(build_file)}")
-
     def check_recipe(self, recipe_name: str, arch_name: str, recipe: RecipeReaderDeps) -> None:
-        recipe_dir: Final[Optional[Path]] = Path(recipe_name) if recipe_name else None
-        # Check root level
-        build_script_path: Final[str] = "/build/script"
-        build_script_val = None
-        if recipe.contains_value(build_script_path):
-            build_script_val = recipe.get_value(build_script_path)
-            if build_script_path := self._check_block(build_script_path, build_script_val):
-                self.message(section=build_script_path)
-        if recipe_dir:
-            self._check_build_sh(recipe_dir, build_script_val)
-        # Check outputs
-        for package in recipe.get_package_paths():
-            if package == "/":
-                continue
-            script_path = recipe.append_to_path(package, "/script")
-            output_build_script_path = recipe.append_to_path(package, "/build/script")
-            script_val = None
-            if recipe.contains_value(script_path):
-                script_val = recipe.get_value(script_path)
-                if script_path := self._check_block(script_path, script_val):
-                    self.message(section=script_path)
-            elif recipe.contains_value(output_build_script_path):
-                script_val = recipe.get_value(output_build_script_path)
-                if output_build_script_path := self._check_block(output_build_script_path, script_val):
-                    self.message(section=output_build_script_path)
-            if recipe_dir:
-                self._check_build_sh(recipe_dir, script_val)
+        self._check_build_script(recipe_name, recipe)
 
     def fix(self, message, data) -> bool:
-        section = message.section
-        if section.startswith("build script: "):
-            return False
-        recipe = self.unrendered_recipe
-        return recipe.patch(
-            {
-                "op": "replace",
-                "path": section,
-                "value": "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation",
-            }
-        )
+        return self._fix_script(message)
 
 
 class python_build_tools_in_host(LintCheck):

--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -581,12 +581,11 @@ class pip_install_args(LintCheck):
         if section.startswith("build script: "):
             return False
         recipe = self.unrendered_recipe
-        recipe.patch(
+        return recipe.patch(
             {
                 "op": "replace",
                 "path": section,
-                "value": "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed"
-                " --no-cache-dir -vv",
+                "value": "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation",
             }
         )
 

--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -513,12 +513,6 @@ class pip_install_args(ScriptCheck):
                 return True
         return False
 
-    def check_recipe(self, recipe_name: str, arch_name: str, recipe: RecipeReaderDeps) -> None:
-        self._check_build_script(recipe_name, recipe)
-
-    def fix(self, message, data) -> bool:
-        return self._fix_script(message)
-
 
 class python_build_tools_in_host(LintCheck):
     """

--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -563,11 +563,16 @@ class pip_install_args(LintCheck):
             if package == "/":
                 continue
             script_path = recipe.append_to_path(package, "/script")
+            output_build_script_path = recipe.append_to_path(package, "/build/script")
             script_val = None
             if recipe.contains_value(script_path):
                 script_val = recipe.get_value(script_path)
                 if script_path := self._check_block(script_path, script_val):
                     self.message(section=script_path)
+            elif recipe.contains_value(output_build_script_path):
+                script_val = recipe.get_value(output_build_script_path)
+                if output_build_script_path := self._check_block(output_build_script_path, script_val):
+                    self.message(section=output_build_script_path)
             if recipe_dir:
                 self._check_build_sh(recipe_dir, script_val)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -186,7 +186,14 @@ def read_recipe_content(recipe_file: str) -> str:
 
 
 # TODO: Passing a specific arch is not a good idea long-term, we should use a more generic approach.
-def assert_lint_messages(recipe_file: str, lint_check: str, msg_title: str, msg_count: int = 1, arch: str = "linux-64"):
+def assert_lint_messages(  # pylint: disable=too-many-positional-arguments
+    recipe_file: str,
+    lint_check: str,
+    msg_title: str,
+    msg_count: int = 1,
+    arch: str = "linux-64",
+    feedstock_dir: Optional[Path] = None,
+):
     """
     Assert that a recipe file has a specific number and type of lint message for a specific lint check.
 
@@ -195,23 +202,33 @@ def assert_lint_messages(recipe_file: str, lint_check: str, msg_title: str, msg_
     :param msg_title: Title of the lint message to check for
     :param msg_count: Number of lint messages to expect
     :param arch: Target architecture to render recipe as
+    :param feedstock_dir: Path to the feedstock directory to read
     """
     recipe_file_path: Final[Path] = get_test_path() / recipe_file
-    messages: Final = check(lint_check, read_recipe_content(recipe_file_path), arch=arch)
+    if feedstock_dir:
+        messages: Final = check_dir(lint_check, feedstock_dir, read_recipe_content(recipe_file_path), arch=arch)
+    else:
+        messages: Final = check(lint_check, read_recipe_content(recipe_file_path), arch=arch)
     assert len(messages) == msg_count and all(msg_title in msg.title for msg in messages)
 
 
 # TODO: Passing a specific arch is not a good idea long-term, we should use a more generic approach.
-def assert_no_lint_message(recipe_file: str, lint_check: str, arch: str = "linux-64") -> None:
+def assert_no_lint_message(
+    recipe_file: str, lint_check: str, arch: str = "linux-64", feedstock_dir: Optional[Path] = None
+) -> None:
     """
     Assert that a recipe file has no lint messages for a specific lint check.
 
     :param recipe_file: Path to the recipe file to read
     :param lint_check: Name of the linting rule. This corresponds with input and output files.
     :param arch: Target architecture to render recipe as
+    :param feedstock_dir: Path to the feedstock directory to read
     """
     recipe_file_path: Final[Path] = get_test_path() / recipe_file
-    messages: Final = check(lint_check, read_recipe_content(recipe_file_path), arch=arch)
+    if feedstock_dir:
+        messages: Final = check_dir(lint_check, feedstock_dir, read_recipe_content(recipe_file_path), arch=arch)
+    else:
+        messages: Final = check(lint_check, read_recipe_content(recipe_file_path), arch=arch)
     assert len(messages) == 0
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -168,7 +168,7 @@ def check_dir(check_name: str, feedstock_dir: str | Path, recipe_str: str, arch:
         recipe=recipe,
         unrendered_recipe=unrendered_recipe,
         percy_recipe=percy_recipe,
-        recipe_name="dummy",
+        recipe_name=str(recipe_directory),
         arch_name=arch,
     )
     return messages

--- a/tests/lint/test_auto_fix_rules.py
+++ b/tests/lint/test_auto_fix_rules.py
@@ -26,6 +26,7 @@ from conftest import assert_on_auto_fix
         ("no_git_on_windows", "", "win-64", 1),
         ("patch_unnecessary", "", "linux-64", 1),
         ("avoid_noarch", "", "linux-64", 2),
+        ("pip_install_args", "", "linux-64", 3),
     ],
 )
 def test_auto_fix_rule(check: str, suffix: str, arch: str, occurrences: int):

--- a/tests/lint/test_build_help.py
+++ b/tests/lint/test_build_help.py
@@ -963,203 +963,98 @@ def test_uses_setup_py_multi_script_missing(base_yaml: str, recipe_dir: Path, ar
     assert len(messages) == 1 and "python setup.py install" in messages[0].title
 
 
-def test_pip_install_args_good_missing(base_yaml: str) -> None:
-    lint_check = "pip_install_args"
-    messages = check(lint_check, base_yaml)
-    assert len(messages) == 0
+@pytest.mark.parametrize(
+    "file,",
+    [
+        "pip_install_args/no_command.yaml",
+    ],
+)
+def test_pip_install_args_no_command_no_script(file: str) -> None:
+    assert_no_lint_message(recipe_file=file, lint_check="pip_install_args")
 
 
-def test_pip_install_args_good_missing_file(base_yaml: str, recipe_dir: Path) -> None:
-    yaml_str = (
-        base_yaml
-        + """
-        requirements:
-          host:
-            - pip
-        """
-    )
-    lint_check = "pip_install_args"
-    messages = check_dir(lint_check, recipe_dir.parent, yaml_str)
-    assert len(messages) == 0
-
-
-def test_pip_install_args_good_cmd(base_yaml: str) -> None:
-    yaml_str = (
-        base_yaml
-        + """
-        build:
-          script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation
-        requirements:
-          host:
-            - pip
-        """
-    )
-    lint_check = "pip_install_args"
-    messages = check(lint_check, yaml_str)
-    assert len(messages) == 0
-
-
-def test_pip_install_args_good_script(base_yaml: str, recipe_dir: Path) -> None:
-    yaml_str = (
-        base_yaml
-        + """
-        requirements:
-          host:
-            - pip
-        """
-    )
-    lint_check = "pip_install_args"
+@pytest.mark.parametrize(
+    "file,",
+    [
+        "pip_install_args/no_command.yaml",
+    ],
+)
+def test_pip_install_args_no_command_valid_script(file: str, recipe_dir: Path) -> None:
     test_file = recipe_dir / "build.sh"
-    test_file.write_text("{{ PYTHON }} -m pip install . --no-deps --no-build-isolation\n")
-    messages = check_dir(lint_check, recipe_dir.parent, yaml_str)
-    assert len(messages) == 0
+    test_file.write_text("$PYTHON -m pip install . --no-deps --no-build-isolation\n")
+    assert_no_lint_message(recipe_file=file, lint_check="pip_install_args", feedstock_dir=recipe_dir.parent)
 
 
-def test_pip_install_args_bad_cmd(base_yaml: str) -> None:
-    yaml_str = (
-        base_yaml
-        + """
-        build:
-          script: {{ PYTHON }} -m pip install .
-        requirements:
-          host:
-            - pip
-        """
-    )
-    lint_check = "pip_install_args"
-    messages = check(lint_check, yaml_str)
-    assert len(messages) == 1 and "should be run with --no-deps and --no-build-isolation" in messages[0].title
+@pytest.mark.parametrize(
+    "file,",
+    [
+        "pip_install_args/command_valid.yaml",
+    ],
+)
+def test_pip_install_args_command_valid(file: str) -> None:
+    assert_no_lint_message(recipe_file=file, lint_check="pip_install_args")
 
 
-def test_pip_install_args_bad_cmd_list(base_yaml: str) -> None:
-    yaml_str = (
-        base_yaml
-        + """
-        build:
-          script:
-            - {{ PYTHON }} -m pip install .
-        requirements:
-          host:
-            - pip
-        """
-    )
-    lint_check = "pip_install_args"
-    messages = check(lint_check, yaml_str)
-    assert len(messages) == 1 and "should be run with --no-deps and --no-build-isolation" in messages[0].title
-
-
-def test_pip_install_args_bad_cmd_multi(base_yaml: str) -> None:
-    yaml_str = (
-        base_yaml
-        + """
-        outputs:
-          - name: output1
-            script: {{ PYTHON }} -m pip install
-            requirements:
-              host:
-                - pip
-          - name: output2
-            script: {{ PYTHON }} -m pip install
-            requirements:
-              host:
-                - pip
-        """
-    )
-    lint_check = "pip_install_args"
-    messages = check(lint_check, yaml_str)
-    assert len(messages) == 2 and all(
-        "should be run with --no-deps and --no-build-isolation" in msg.title for msg in messages
+@pytest.mark.parametrize(
+    "file,",
+    [
+        "pip_install_args/command_missing_no_deps.yaml",
+        "pip_install_args/command_missing_no_build.yaml",
+    ],
+)
+def test_pip_install_args_command_missing_args(file: str) -> None:
+    assert_lint_messages(
+        recipe_file=file,
+        lint_check="pip_install_args",
+        msg_title="should be run with --no-deps and --no-build-isolation",
+        msg_count=1,
     )
 
 
-def test_pip_install_args_bad_cmd_multi_list(base_yaml: str) -> None:
-    yaml_str = (
-        base_yaml
-        + """
-        outputs:
-          - name: output1
-            script:
-              - {{ PYTHON }} -m pip install
-            requirements:
-              host:
-                - pip
-          - name: output2
-            script: {{ PYTHON }} -m pip install
-            requirements:
-              host:
-                - pip
-        """
-    )
-    lint_check = "pip_install_args"
-    messages = check(lint_check, yaml_str)
-    assert len(messages) == 2 and all(
-        "should be run with --no-deps and --no-build-isolation" in msg.title for msg in messages
+@pytest.mark.parametrize(
+    "file,",
+    [
+        "pip_install_args/command_missing_args_multi.yaml",
+    ],
+)
+def test_pip_install_args_command_missing_args_multi(file: str) -> None:
+    assert_lint_messages(
+        recipe_file=file,
+        lint_check="pip_install_args",
+        msg_title="should be run with --no-deps and --no-build-isolation",
+        msg_count=3,
     )
 
 
-def test_pip_install_args_bad_script(base_yaml: str, recipe_dir: Path) -> None:
-    yaml_str = (
-        base_yaml
-        + """
-        requirements:
-          host:
-            - pip
-        """
-    )
-    lint_check = "pip_install_args"
-    test_file = recipe_dir / "build.sh"
+@pytest.mark.parametrize(
+    "file,",
+    [
+        "pip_install_args/command_valid_multi.yaml",
+    ],
+)
+def test_pip_install_args_command_valid_multi(file: str) -> None:
+    assert_no_lint_message(recipe_file=file, lint_check="pip_install_args")
+
+
+@pytest.mark.parametrize(
+    "file,script_file,msg_count",
+    [
+        ("pip_install_args/no_command.yaml", "build.sh", 1),
+        ("pip_install_args/script_command.yaml", "build_script.sh", 1),
+        ("pip_install_args/script_command_multi.yaml", "build_output.sh", 3),
+        ("pip_install_args/script_command_multi_missing_one.yaml", "build_output.sh", 2),
+    ],
+)
+def test_pip_install_args_invalid_script(file: str, script_file: str, msg_count: int, recipe_dir: Path) -> None:
+    test_file = recipe_dir / script_file
     test_file.write_text("{{ PYTHON }} -m pip install .\n")
-    messages = check_dir(lint_check, recipe_dir.parent, yaml_str)
-    assert len(messages) == 1 and "should be run with --no-deps and --no-build-isolation" in messages[0].title
-
-
-def test_pip_install_args_bad_script_multi(base_yaml: str, recipe_dir: Path) -> None:
-    yaml_str = (
-        base_yaml
-        + """
-        outputs:
-          - name: output1
-            script: build_output.sh
-            requirements:
-              host:
-                - pip
-          - name: output2
-            script: build_output.sh
-            requirements:
-              host:
-                - pip
-        """
+    assert_lint_messages(
+        recipe_file=file,
+        lint_check="pip_install_args",
+        msg_title="should be run with --no-deps and --no-build-isolation",
+        msg_count=msg_count,
+        feedstock_dir=recipe_dir.parent,
     )
-    lint_check = "pip_install_args"
-    test_file = recipe_dir / "build_output.sh"
-    test_file.write_text("{{ PYTHON }} -m pip install .\n")
-    messages = check_dir(lint_check, recipe_dir.parent, yaml_str)
-    assert len(messages) == 2 and all(
-        "should be run with --no-deps and --no-build-isolation" in msg.title for msg in messages
-    )
-
-
-def test_pip_install_args_multi_script_missing(base_yaml: str, recipe_dir: Path) -> None:
-    yaml_str = (
-        base_yaml
-        + """
-        outputs:
-          - name: output1
-            script: build_output.sh
-            requirements:
-              host:
-                - pip
-          - name: output2
-            requirements:
-              host:
-                - pip
-        """
-    )
-    lint_check = "pip_install_args"
-    test_file = recipe_dir / "build_output.sh"
-    test_file.write_text("{{ PYTHON }} -m pip install .\n")
-    messages = check_dir(lint_check, recipe_dir.parent, yaml_str)
-    assert len(messages) == 1 and "should be run with --no-deps and --no-build-isolation" in messages[0].title
 
 
 def test_python_build_tools_in_host_all_in_host() -> None:

--- a/tests/test_aux_files/auto_fix/pip_install_args.yaml
+++ b/tests/test_aux_files/auto_fix/pip_install_args.yaml
@@ -19,7 +19,8 @@ outputs:
       host:
         - pip
   - name: output2
-    script: {{ PYTHON }} -m pip install . --no-build-isolation
+    build:
+      script: {{ PYTHON }} -m pip install . --no-build-isolation
     requirements:
       host:
         - pip

--- a/tests/test_aux_files/auto_fix/pip_install_args.yaml
+++ b/tests/test_aux_files/auto_fix/pip_install_args.yaml
@@ -1,0 +1,30 @@
+package:
+  name: package_name
+  version: 0.0.1
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install .
+
+requirements:
+  host:
+    - pip
+  run:
+    - python
+
+outputs:
+  - name: output1
+    script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation
+    requirements:
+      host:
+        - pip
+  - name: output2
+    script: {{ PYTHON }} -m pip install . --no-build-isolation
+    requirements:
+      host:
+        - pip
+  - name: output3
+    script: {{ PYTHON }} -m pip install . --no-deps
+    requirements:
+      host:
+        - pip

--- a/tests/test_aux_files/auto_fix/pip_install_args.yaml
+++ b/tests/test_aux_files/auto_fix/pip_install_args.yaml
@@ -25,7 +25,9 @@ outputs:
       host:
         - pip
   - name: output3
-    script: {{ PYTHON }} -m pip install . --no-deps
+    script:
+      - dummy_command
+      - {{ PYTHON }} -m pip install . --no-deps
     requirements:
       host:
         - pip

--- a/tests/test_aux_files/auto_fix/pip_install_args_fixed.yaml
+++ b/tests/test_aux_files/auto_fix/pip_install_args_fixed.yaml
@@ -19,7 +19,8 @@ outputs:
       host:
         - pip
   - name: output2
-    script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation
+    build:
+      script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation
     requirements:
       host:
         - pip

--- a/tests/test_aux_files/auto_fix/pip_install_args_fixed.yaml
+++ b/tests/test_aux_files/auto_fix/pip_install_args_fixed.yaml
@@ -25,7 +25,9 @@ outputs:
       host:
         - pip
   - name: output3
-    script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation
+    script:
+      - dummy_command
+      - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation
     requirements:
       host:
         - pip

--- a/tests/test_aux_files/auto_fix/pip_install_args_fixed.yaml
+++ b/tests/test_aux_files/auto_fix/pip_install_args_fixed.yaml
@@ -1,0 +1,30 @@
+package:
+  name: package_name
+  version: 0.0.1
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - pip
+  run:
+    - python
+
+outputs:
+  - name: output1
+    script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation
+    requirements:
+      host:
+        - pip
+  - name: output2
+    script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation
+    requirements:
+      host:
+        - pip
+  - name: output3
+    script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation
+    requirements:
+      host:
+        - pip

--- a/tests/test_aux_files/pip_install_args/command_missing_args_multi.yaml
+++ b/tests/test_aux_files/pip_install_args/command_missing_args_multi.yaml
@@ -1,0 +1,25 @@
+package:
+  name: package_name
+  version: 0.0.1
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install .
+
+requirements:
+  host:
+    - pip
+  run:
+    - python
+
+outputs:
+  - name: output1
+    script: {{ PYTHON }} -m pip install . --no-build-isolation
+    requirements:
+      host:
+        - pip
+  - name: output2
+    script: {{ PYTHON }} -m pip install . --no-deps
+    requirements:
+      host:
+        - pip

--- a/tests/test_aux_files/pip_install_args/command_missing_no_build.yaml
+++ b/tests/test_aux_files/pip_install_args/command_missing_no_build.yaml
@@ -1,0 +1,13 @@
+package:
+  name: package_name
+  version: 0.0.1
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps
+
+requirements:
+  host:
+    - pip
+  run:
+    - python

--- a/tests/test_aux_files/pip_install_args/command_missing_no_deps.yaml
+++ b/tests/test_aux_files/pip_install_args/command_missing_no_deps.yaml
@@ -1,0 +1,13 @@
+package:
+  name: package_name
+  version: 0.0.1
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-build-isolation
+
+requirements:
+  host:
+    - pip
+  run:
+    - python

--- a/tests/test_aux_files/pip_install_args/command_valid.yaml
+++ b/tests/test_aux_files/pip_install_args/command_valid.yaml
@@ -1,0 +1,13 @@
+package:
+  name: package_name
+  version: 0.0.1
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - pip
+  run:
+    - python

--- a/tests/test_aux_files/pip_install_args/command_valid_multi.yaml
+++ b/tests/test_aux_files/pip_install_args/command_valid_multi.yaml
@@ -1,0 +1,25 @@
+package:
+  name: package_name
+  version: 0.0.1
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - pip
+  run:
+    - python
+
+outputs:
+  - name: output1
+    script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation
+    requirements:
+      host:
+        - pip
+  - name: output2
+    script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation
+    requirements:
+      host:
+        - pip

--- a/tests/test_aux_files/pip_install_args/no_command.yaml
+++ b/tests/test_aux_files/pip_install_args/no_command.yaml
@@ -1,0 +1,12 @@
+package:
+  name: package_name
+  version: 0.0.1
+
+build:
+  number: 0
+
+requirements:
+  host:
+    - pip
+  run:
+    - python

--- a/tests/test_aux_files/pip_install_args/script_command.yaml
+++ b/tests/test_aux_files/pip_install_args/script_command.yaml
@@ -1,0 +1,13 @@
+package:
+  name: package_name
+  version: 0.0.1
+
+build:
+  number: 0
+  script: build_script.sh
+
+requirements:
+  host:
+    - pip
+  run:
+    - python

--- a/tests/test_aux_files/pip_install_args/script_command_multi.yaml
+++ b/tests/test_aux_files/pip_install_args/script_command_multi.yaml
@@ -1,0 +1,25 @@
+package:
+  name: package_name
+  version: 0.0.1
+
+build:
+  number: 0
+  script: build_output.sh
+
+requirements:
+  host:
+    - pip
+  run:
+    - python
+
+outputs:
+  - name: output1
+    script: build_output.sh
+    requirements:
+      host:
+        - pip
+  - name: output2
+    script: build_output.sh
+    requirements:
+      host:
+        - pip

--- a/tests/test_aux_files/pip_install_args/script_command_multi_missing_one.yaml
+++ b/tests/test_aux_files/pip_install_args/script_command_multi_missing_one.yaml
@@ -1,0 +1,24 @@
+package:
+  name: package_name
+  version: 0.0.1
+
+build:
+  number: 0
+  script: build_output.sh
+
+requirements:
+  host:
+    - pip
+  run:
+    - python
+
+outputs:
+  - name: output1
+    script: build_output.sh
+    requirements:
+      host:
+        - pip
+  - name: output2
+    requirements:
+      host:
+        - pip


### PR DESCRIPTION
- `/build/script` is checked at the root level of the recipe:
  - If it is absent, or an empty key: `build.sh` is checked in the recipe dir.
  - If it is present:
    - it is checked for an incorrect `pip install` cmd.
    - we also check whether it points to a file, then check that file.
- `script` is similarly checked at each output, failing that `build/script` is checked.
- In the cases of errors within the recipe, `fix()` performs a `replace` patch.
-  Most of this logic is grouped in a new `ScriptCheck` class, since other rules (`uses_setup_py` for example) need to re-use it.
- Tests are updated, including auto-fix.