### PR TITLE
Update Linter Rule: uses_setup_py

### DIFF
--- a/anaconda_linter/lint/__init__.py
+++ b/anaconda_linter/lint/__init__.py
@@ -508,6 +508,8 @@ class ScriptCheck(LintCheck):
     def _check_line(self, line: str) -> bool:
         """
         Check a line for an invalid or obsolete install command
+
+        :returns: True if the line contains an invalid or obsolete install command
         """
 
     def _check_block(self, path: str, value: Any) -> str:

--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -431,7 +431,7 @@ class uses_setup_py(LintCheck):
 
     Please use::
 
-        $PYTHON -m pip install . --no-deps --no-build-isolation
+        {{ PYTHON }} -m pip install . --no-deps --no-build-isolation
 
     Or use another python build tool.
     """

--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import os
 import re
-from pathlib import Path
 from typing import Final
 
 from conda.models.match_spec import MatchSpec
@@ -425,75 +424,28 @@ class missing_python_build_tool(LintCheck):
                 self.message(section="requirements/host")
 
 
-class uses_setup_py(LintCheck):
+class deprecated_python_install_command(ScriptCheck):
     """
-    `python setup.py install` is deprecated.
+    The python install command used in the build script is deprecated.
 
     Please use::
 
         {{ PYTHON }} -m pip install . --no-deps --no-build-isolation
-
-    Or use another python build tool.
     """
 
-    @staticmethod
-    def _check_line(x: str) -> bool:
-        """
-        Check a line for a broken call to setup.py
-        """
-        if isinstance(x, str):
-            x = [x]
-        elif not isinstance(x, list):
-            return True
-        for line in x:
-            if "setup.py install" in line:
-                return False
-        return True
+    # Regex pattern to match deprecated python install commands
+    # Matches: python/PYTHON variants + optional -m + (setup.py|build), or pip wheel
+    deprecated_command_pattern = re.compile(
+        r"(?:(?:\$\{?PYTHON\}?|\{\{\s*PYTHON\s*\}\}|python)\s+(?:-m\s+)?(?:setup\.py|build)|pip\s+wheel)"
+    )
 
-    def check_recipe_legacy(self, recipe: Recipe) -> None:
-        for package in recipe.packages.values():
-            if not self._check_line(recipe.get(f"{package.path_prefix}build/script", None)):
-                self.message(
-                    section=f"{package.path_prefix}build/script",
-                    data=(recipe, f"{package.path_prefix}build/script"),
-                )
-            elif not self._check_line(recipe.get(f"{package.path_prefix}script", None)):
-                self.message(
-                    section=f"{package.path_prefix}script",
-                    data=(recipe, f"{package.path_prefix}script"),
-                )
-            elif self.percy_recipe.dir:
-                try:
-                    build_file = self.percy_recipe.get(f"{package.path_prefix}script", "")
-                    if not build_file:
-                        build_file = self.percy_recipe.get(f"{package.path_prefix}build/script", "build.sh")
-                    build_file = self.percy_recipe.dir / Path(build_file)
-                    if build_file.exists():
-                        with open(str(build_file), encoding="utf-8") as buildsh:
-                            for line in buildsh:
-                                if not self._check_line(line):
-                                    if package.path_prefix.startswith("output"):
-                                        output = int(package.path_prefix.split("/")[1])
-                                    else:
-                                        output = -1
-                                    self.message(fname=build_file, output=output)
-                except (FileNotFoundError, TypeError):
-                    pass
+    def _check_line(self, line: str) -> bool:
+        """
+        Check a line for an invalid or obsolete install command
 
-    def fix(self, message, data) -> bool:
-        (recipe, path) = data
-        op = [
-            {
-                "op": "replace",
-                "path": path,
-                "match": ".* setup.py .*",
-                "value": (
-                    "{{PYTHON}} -m pip install . --no-deps --no-build-isolation --ignore-installed"
-                    " --no-cache-dir -vv"
-                ),
-            },
-        ]
-        return recipe.patch(op)
+        :returns: True if the line contains an invalid or obsolete install command
+        """
+        return bool(self.deprecated_command_pattern.search(line))
 
 
 class pip_install_args(ScriptCheck):
@@ -507,6 +459,11 @@ class pip_install_args(ScriptCheck):
     """
 
     def _check_line(self, line: str) -> bool:
+        """
+        Check a line for an invalid or obsolete install command
+
+        :returns: True if the line contains an invalid or obsolete install command
+        """
         if "pip install" in line:
             required_args = ["--no-deps", "--no-build-isolation"]
             if any(arg not in line for arg in required_args):

--- a/anaconda_linter/lint_names.md
+++ b/anaconda_linter/lint_names.md
@@ -108,7 +108,7 @@ unknown_check
 
 unknown_selector
 
-uses_setup_py
+deprecated_python_install_command
 
 version_constraints_missing_whitespace
 

--- a/tests/lint/test_auto_fix_rules.py
+++ b/tests/lint/test_auto_fix_rules.py
@@ -27,6 +27,7 @@ from conftest import assert_on_auto_fix
         ("patch_unnecessary", "", "linux-64", 1),
         ("avoid_noarch", "", "linux-64", 2),
         ("pip_install_args", "", "linux-64", 3),
+        ("deprecated_python_install_command", "", "linux-64", 3),
     ],
 )
 def test_auto_fix_rule(check: str, suffix: str, arch: str, occurrences: int):

--- a/tests/test_aux_files/auto_fix/deprecated_python_install_command.yaml
+++ b/tests/test_aux_files/auto_fix/deprecated_python_install_command.yaml
@@ -1,0 +1,33 @@
+package:
+  name: package_name
+  version: 0.0.1
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip wheel
+
+requirements:
+  host:
+    - pip
+  run:
+    - python
+
+outputs:
+  - name: output1
+    script: python -m build
+    requirements:
+      host:
+        - pip
+  - name: output2
+    build:
+      script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation
+    requirements:
+      host:
+        - pip
+  - name: output3
+    script:
+      - dummy_command
+      - python -m setup.py install --no-deps
+    requirements:
+      host:
+        - pip

--- a/tests/test_aux_files/auto_fix/deprecated_python_install_command_fixed.yaml
+++ b/tests/test_aux_files/auto_fix/deprecated_python_install_command_fixed.yaml
@@ -1,0 +1,33 @@
+package:
+  name: package_name
+  version: 0.0.1
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - pip
+  run:
+    - python
+
+outputs:
+  - name: output1
+    script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation
+    requirements:
+      host:
+        - pip
+  - name: output2
+    build:
+      script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation
+    requirements:
+      host:
+        - pip
+  - name: output3
+    script:
+      - dummy_command
+      - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation
+    requirements:
+      host:
+        - pip

--- a/tests/test_aux_files/deprecated_python_install_command/command_pip_wheel_multi_and_list.yaml
+++ b/tests/test_aux_files/deprecated_python_install_command/command_pip_wheel_multi_and_list.yaml
@@ -1,0 +1,26 @@
+package:
+  name: package_name
+  version: 0.0.1
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip wheel
+
+requirements:
+  host:
+    - pip
+  run:
+    - python
+
+outputs:
+  - name: output1
+    script: pip wheel
+    requirements:
+      host:
+        - pip
+  - name: output2
+    script: 
+      - $PYTHON -m pip wheel
+    requirements:
+      host:
+        - pip

--- a/tests/test_aux_files/deprecated_python_install_command/command_python_build_multi_and_list.yaml
+++ b/tests/test_aux_files/deprecated_python_install_command/command_python_build_multi_and_list.yaml
@@ -1,0 +1,26 @@
+package:
+  name: package_name
+  version: 0.0.1
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m build
+
+requirements:
+  host:
+    - pip
+  run:
+    - python
+
+outputs:
+  - name: output1
+    script: python -m build
+    requirements:
+      host:
+        - pip
+  - name: output2
+    script: 
+      - $PYTHON -m build
+    requirements:
+      host:
+        - pip

--- a/tests/test_aux_files/deprecated_python_install_command/command_setup_py_multi_and_list.yaml
+++ b/tests/test_aux_files/deprecated_python_install_command/command_setup_py_multi_and_list.yaml
@@ -1,0 +1,26 @@
+package:
+  name: package_name
+  version: 0.0.1
+
+build:
+  number: 0
+  script: {{ PYTHON }} setup.py install --no-deps
+
+requirements:
+  host:
+    - pip
+  run:
+    - python
+
+outputs:
+  - name: output1
+    script: $PYTHON -m setup.py install --no-build-isolation
+    requirements:
+      host:
+        - pip
+  - name: output2
+    script: 
+      - python -m setup.py install --no-deps
+    requirements:
+      host:
+        - pip

--- a/tests/test_aux_files/deprecated_python_install_command/command_valid.yaml
+++ b/tests/test_aux_files/deprecated_python_install_command/command_valid.yaml
@@ -1,0 +1,13 @@
+package:
+  name: package_name
+  version: 0.0.1
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - pip
+  run:
+    - python

--- a/tests/test_aux_files/deprecated_python_install_command/command_valid_multi.yaml
+++ b/tests/test_aux_files/deprecated_python_install_command/command_valid_multi.yaml
@@ -1,0 +1,25 @@
+package:
+  name: package_name
+  version: 0.0.1
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - pip
+  run:
+    - python
+
+outputs:
+  - name: output1
+    script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation
+    requirements:
+      host:
+        - pip
+  - name: output2
+    script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation
+    requirements:
+      host:
+        - pip

--- a/tests/test_aux_files/deprecated_python_install_command/no_command.yaml
+++ b/tests/test_aux_files/deprecated_python_install_command/no_command.yaml
@@ -1,0 +1,12 @@
+package:
+  name: package_name
+  version: 0.0.1
+
+build:
+  number: 0
+
+requirements:
+  host:
+    - pip
+  run:
+    - python

--- a/tests/test_aux_files/deprecated_python_install_command/script_command.yaml
+++ b/tests/test_aux_files/deprecated_python_install_command/script_command.yaml
@@ -1,0 +1,13 @@
+package:
+  name: package_name
+  version: 0.0.1
+
+build:
+  number: 0
+  script: build_script.sh
+
+requirements:
+  host:
+    - pip
+  run:
+    - python

--- a/tests/test_aux_files/deprecated_python_install_command/script_command_multi.yaml
+++ b/tests/test_aux_files/deprecated_python_install_command/script_command_multi.yaml
@@ -1,0 +1,25 @@
+package:
+  name: package_name
+  version: 0.0.1
+
+build:
+  number: 0
+  script: build_output.sh
+
+requirements:
+  host:
+    - pip
+  run:
+    - python
+
+outputs:
+  - name: output1
+    script: build_output.sh
+    requirements:
+      host:
+        - pip
+  - name: output2
+    script: build_output.sh
+    requirements:
+      host:
+        - pip

--- a/tests/test_aux_files/deprecated_python_install_command/script_command_multi_missing_one.yaml
+++ b/tests/test_aux_files/deprecated_python_install_command/script_command_multi_missing_one.yaml
@@ -1,0 +1,24 @@
+package:
+  name: package_name
+  version: 0.0.1
+
+build:
+  number: 0
+  script: build_output.sh
+
+requirements:
+  host:
+    - pip
+  run:
+    - python
+
+outputs:
+  - name: output1
+    script: build_output.sh
+    requirements:
+      host:
+        - pip
+  - name: output2
+    requirements:
+      host:
+        - pip


### PR DESCRIPTION
Here, we:
- update `uses_setup_py` -> `deprecated_python_install_command` and its implementation using the `ScriptCheck`class.
- update testing and add auto-fix testing.