### PR TITLE
Linter Rule Update: should_use_stdlib

### DIFF
--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -103,7 +103,7 @@ COMPILERS: Final[tuple] = (
     "toolchain",
 )
 
-STDLIBS: Final[list] = ["sysroot", "macosx_deployment_target", "vs"]  # linux  # osx  # windows
+STDLIBS: Final[set] = {"sysroot", "macosx_deployment_target", "vs"}  # linux  # osx  # windows
 
 # Allowlist for noarch packages
 NOARCH_ALLOWLIST: Final[set] = {*PYTHON_BUILD_TOOLS}

--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -324,7 +324,7 @@ class should_use_stdlib(LintCheck):
                     self.message(section=dep.path)
                 elif dep.data.name == "stdlib_c":
                     stdlib_dep = dep
-                elif dep.data.name == "compiler_c":
+                elif dep.data.name.startswith("compiler_"):
                     compiler_dep = dep
             if compiler_dep and not stdlib_dep:
                 # Output has a compiler but is missing a stdlib dependency.

--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -103,7 +103,7 @@ COMPILERS: Final[tuple] = (
     "toolchain",
 )
 
-STDLIBS: Final[tuple] = ("sysroot", "macosx_deployment_target", "vs")  # linux  # osx  # windows
+STDLIBS: Final[list] = ["sysroot", "macosx_deployment_target", "vs"]  # linux  # osx  # windows
 
 # Allowlist for noarch packages
 NOARCH_ALLOWLIST: Final[set] = {*PYTHON_BUILD_TOOLS}
@@ -309,36 +309,26 @@ class should_use_stdlib(LintCheck):
 
     """
 
-    # NOTE: This is a temporary fix since LintCheck.check_deps() is deprecated
-    def _check_deps(self, deps) -> None:
-        """
-        Checks for manual use of the `sysroot`, `macosx_deployment_target` or `vs` packages in recipes.
-        """
-        for stdlib in STDLIBS:
-            for location in deps.get(stdlib, {}).get("paths", []):
-                self.message(section=location)
-
-    def check_recipe_legacy(self, recipe: Recipe) -> None:
-        """
-        Ensures a {{ stdlib('c') }} macro is used in any recipe using a compiler.
-        """
-        stdlib_name = (
-            f"{recipe.selector_dict.get('c_stdlib', 'unknown_stdlib')}_"
-            f"{recipe.selector_dict.get('target_platform', 'unknown_target_platform')}"
-        )
-        for output in recipe.packages.values():
+    def check_recipe(self, recipe_name: str, arch_name: str, recipe: RecipeReaderDeps) -> None:
+        all_deps: Final = recipe.get_all_dependencies()
+        for output in all_deps:
+            stdlib_dep = None
             compiler_dep = None
-            for dep in output.build:
-                if dep.pkg == stdlib_name:
-                    break  # Found a stdlib dependency, all good.
-                elif dep.pkg.startswith("compiler_"):
+            for dep in all_deps[output]:
+                if stdlib_dep and compiler_dep:
+                    break
+                if dep.type != DependencySection.BUILD:
+                    continue
+                if dep.data.name in STDLIBS:
+                    # Bypassing the stdlib macro is not allowed.
+                    self.message(section=dep.path)
+                elif dep.data.name == "stdlib_c":
+                    stdlib_dep = dep
+                elif dep.data.name == "compiler_c":
                     compiler_dep = dep
-            else:
-                if compiler_dep:
-                    # Output has a compiler but is missing a stdlib dependency.
-                    self.message(section=compiler_dep.path)
-
-        self._check_deps(_utils.get_deps_dict(recipe))
+            if compiler_dep and not stdlib_dep:
+                # Output has a compiler but is missing a stdlib dependency.
+                self.message(section=compiler_dep.path)
 
 
 class stdlib_must_be_in_build(LintCheck):

--- a/tests/test_aux_files/should_use_stdlib/stdlib_missing.yaml
+++ b/tests/test_aux_files/should_use_stdlib/stdlib_missing.yaml
@@ -1,0 +1,7 @@
+package:
+  name: test
+  version: 0.1.0
+
+requirements:
+  build:
+    - {{ compiler('c') }}

--- a/tests/test_aux_files/should_use_stdlib/stdlib_missing_multi.yaml
+++ b/tests/test_aux_files/should_use_stdlib/stdlib_missing_multi.yaml
@@ -1,0 +1,17 @@
+package:
+  name: test
+  version: 0.1.0
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+
+outputs:
+  - name: output1
+    requirements:
+      build:
+        - {{ compiler('c') }}
+  - name: output2
+    requirements:
+      build:
+        - {{ compiler('c') }}

--- a/tests/test_aux_files/should_use_stdlib/stdlib_missing_multi.yaml
+++ b/tests/test_aux_files/should_use_stdlib/stdlib_missing_multi.yaml
@@ -10,8 +10,8 @@ outputs:
   - name: output1
     requirements:
       build:
-        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
   - name: output2
     requirements:
       build:
-        - {{ compiler('c') }}
+        - {{ compiler('fortran') }}

--- a/tests/test_aux_files/should_use_stdlib/stdlib_missing_multi.yaml
+++ b/tests/test_aux_files/should_use_stdlib/stdlib_missing_multi.yaml
@@ -4,7 +4,7 @@ package:
 
 requirements:
   build:
-    - {{ compiler('c') }}
+    - {{ compiler('go') }}
 
 outputs:
   - name: output1

--- a/tests/test_aux_files/should_use_stdlib/stdlib_present.yaml
+++ b/tests/test_aux_files/should_use_stdlib/stdlib_present.yaml
@@ -1,0 +1,7 @@
+package:
+  name: test
+  version: 0.1.0
+
+requirements:
+  build:
+    - {{ stdlib('c') }}

--- a/tests/test_aux_files/should_use_stdlib/stdlib_present_directly.yaml
+++ b/tests/test_aux_files/should_use_stdlib/stdlib_present_directly.yaml
@@ -1,0 +1,9 @@
+package:
+  name: test
+  version: 0.1.0
+
+requirements:
+  build:
+    - sysroot
+    - macosx_deployment_target
+    - vs

--- a/tests/test_aux_files/should_use_stdlib/stdlib_present_directly_multi.yaml
+++ b/tests/test_aux_files/should_use_stdlib/stdlib_present_directly_multi.yaml
@@ -1,0 +1,23 @@
+package:
+  name: test
+  version: 0.1.0
+
+requirements:
+  build:
+    - sysroot
+    - macosx_deployment_target
+    - vs
+
+outputs:
+  - name: output1
+    requirements:
+      build:
+        - sysroot
+  - name: output2
+    requirements:
+      build:
+        - macosx_deployment_target
+  - name: output3
+    requirements:
+      build:
+        - vs


### PR DESCRIPTION
Re-implemented `should_use_stdlib` to require `{{ stdlib('c') }}` if:
- The macro is not used, and a stdlib is used directly (example: `vs`)
- `{{ compiler('lang') }}` is used but the `{{ stdlib('c') }}` macro is missing
- Updated testing.