### PR TITLE
Update Linter Rule: outputs_not_unique

### DIFF
--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -185,7 +185,12 @@ class host_section_needs_exact_pinnings(LintCheck):
         return False
 
     def check_recipe(self, recipe_name: str, arch_name: str, recipe: RecipeReaderDeps) -> None:
-        for dependency_list in recipe.get_all_dependencies().values():
+        try:
+            all_deps: Final = recipe.get_all_dependencies()
+        except (KeyError, ValueError):
+            self.message(title_in=_utils.GET_ALL_DEPENDENCIES_ERROR_MESSAGE)
+            return
+        for dependency_list in all_deps.values():
             for dependency in dependency_list:
                 if self._check_dependency(dependency):
                     self.message(section=dependency.path, severity=Severity.WARNING)
@@ -265,7 +270,11 @@ class should_use_compilers(LintCheck):
     compilers = COMPILERS
 
     def check_recipe(self, recipe_name: str, arch_name: str, recipe: RecipeReaderDeps) -> None:
-        all_deps: Final = recipe.get_all_dependencies()
+        try:
+            all_deps: Final = recipe.get_all_dependencies()
+        except (KeyError, ValueError):
+            self.message(title_in=_utils.GET_ALL_DEPENDENCIES_ERROR_MESSAGE)
+            return
         problem_paths: set[str] = set()
         for output in all_deps:
             for dep in all_deps[output]:
@@ -286,7 +295,11 @@ class compilers_must_be_in_build(LintCheck):
     """
 
     def check_recipe(self, recipe_name: str, arch_name: str, recipe: RecipeReaderDeps) -> None:
-        all_deps: Final = recipe.get_all_dependencies()
+        try:
+            all_deps: Final = recipe.get_all_dependencies()
+        except (KeyError, ValueError):
+            self.message(title_in=_utils.GET_ALL_DEPENDENCIES_ERROR_MESSAGE)
+            return
         problem_paths: set[str] = set()
         for output in all_deps:
             for dep in all_deps[output]:
@@ -351,7 +364,11 @@ class stdlib_must_be_in_build(LintCheck):
     """
 
     def check_recipe(self, recipe_name: str, arch_name: str, recipe: RecipeReaderDeps) -> None:
-        all_deps: Final = recipe.get_all_dependencies()
+        try:
+            all_deps: Final = recipe.get_all_dependencies()
+        except (KeyError, ValueError):
+            self.message(title_in=_utils.GET_ALL_DEPENDENCIES_ERROR_MESSAGE)
+            return
         problem_paths: set[str] = set()
         for output in all_deps:
             for dep in all_deps[output]:
@@ -528,8 +545,12 @@ class python_build_tools_in_host(LintCheck):
     """
 
     def check_recipe(self, recipe_name: str, arch_name: str, recipe: RecipeReaderDeps) -> None:
+        try:
+            all_deps: Final = recipe.get_all_dependencies()
+        except (KeyError, ValueError):
+            self.message(title_in=_utils.GET_ALL_DEPENDENCIES_ERROR_MESSAGE)
+            return
         problem_paths: set[str] = set()
-        all_deps = recipe.get_all_dependencies()
         for output in all_deps:
             for dep in all_deps[output]:
                 if dep.data.name in PYTHON_BUILD_TOOLS and dep.type != DependencySection.HOST:
@@ -552,7 +573,11 @@ class cython_needs_compiler(LintCheck):
     """
 
     def check_recipe(self, recipe_name: str, arch_name: str, recipe: RecipeReaderDeps) -> None:
-        all_deps: Final = recipe.get_all_dependencies()
+        try:
+            all_deps: Final = recipe.get_all_dependencies()
+        except (KeyError, ValueError):
+            self.message(title_in=_utils.GET_ALL_DEPENDENCIES_ERROR_MESSAGE)
+            return
         for output in all_deps:
             cython = None
             compiler = None
@@ -669,7 +694,13 @@ class avoid_noarch(LintCheck):
 
         # Extract python version
         py_version = None
-        for dep in recipe.get_all_dependencies()[name]:
+        try:
+            all_deps: Final = recipe.get_all_dependencies()
+        except (KeyError, ValueError):
+            self.message(title_in=_utils.GET_ALL_DEPENDENCIES_ERROR_MESSAGE)
+            all_deps = {name: []}
+
+        for dep in all_deps[name]:
             dep_data = dep.data
             if not isinstance(dep_data, MatchSpec):
                 continue
@@ -715,17 +746,64 @@ class patch_unnecessary(LintCheck):
     """
 
     def check_recipe(self, recipe_name: str, arch_name: str, recipe: RecipeReaderDeps) -> None:
-        all_deps = recipe.get_all_dependencies()
+        try:
+            all_deps: Final = recipe.get_all_dependencies()
+        except (KeyError, ValueError):
+            self.message(title_in=_utils.GET_ALL_DEPENDENCIES_ERROR_MESSAGE)
+            return
         for package in all_deps:
             for dep in all_deps[package]:
                 if dep.data.name in ["patch", "msys2-patch", "m2-patch"]:
                     self.message(section=dep.path)
                     return
 
+    def _remove_single_dep_by_name_crm(
+        self,
+        recipe_parser: RecipeParserDeps,
+        deps_to_remove: set[str],
+    ) -> bool:
+        """
+        Removes the dependencies specified by name
+
+        :param recipe_parser: The parser of the original recipe
+        :param deps_to_remove: Set of dependency names to remove
+        :raises ValueError: If the remove operation fails
+        :returns: Whether the remove operation is complete
+        """
+        try:
+            all_deps: Final = recipe_parser.get_all_dependencies()
+        except (KeyError, ValueError) as e:
+            self.message(title_in=_utils.GET_ALL_DEPENDENCIES_ERROR_MESSAGE)
+            raise ValueError from e
+        for package_name in all_deps:
+            for dep in all_deps[package_name]:
+                if dep.data.name not in deps_to_remove:
+                    continue
+                if not recipe_parser.remove_dependency(dep):
+                    self.message(title_in=f"Failed to remove dependency {dep.data.name} from {package_name}")
+                    raise ValueError
+                return False
+        return True
+
+    def _remove_deps_by_name_crm(
+        self,
+        recipe_parser: RecipeParserDeps,
+        deps_to_remove: set[str],
+    ) -> None:
+        """
+        Removes the dependencies specified by name
+
+        :param recipe_parser: The parser of the original recipe
+        :param deps_to_remove: Set of dependency names to remove
+        :raises ValueError: If the remove operation fails
+        """
+        while not self._remove_single_dep_by_name_crm(recipe_parser, deps_to_remove):
+            pass
+
     def fix(self, message, data) -> bool:
         # remove patch/msys2-patch/m2-patch from the recipe
         try:
-            _utils.remove_deps_by_name_crm(self.unrendered_recipe, {"patch", "msys2-patch", "m2-patch"})
+            self._remove_deps_by_name_crm(self.unrendered_recipe, {"patch", "msys2-patch", "m2-patch"})
             return True
         except ValueError:
             return False
@@ -1046,7 +1124,11 @@ class no_git_on_windows(LintCheck):
     def check_recipe(self, recipe_name: str, arch_name: str, recipe: RecipeReaderDeps) -> None:
         if not arch_name.startswith("win"):
             return
-        all_deps = recipe.get_all_dependencies()
+        try:
+            all_deps: Final = recipe.get_all_dependencies()
+        except (KeyError, ValueError):
+            self.message(title_in=_utils.GET_ALL_DEPENDENCIES_ERROR_MESSAGE)
+            return
         for output in all_deps:
             for dep in all_deps[output]:
                 if dep.data.name == "git":
@@ -1057,10 +1139,16 @@ class no_git_on_windows(LintCheck):
         # NOTE: The path found in `check_recipe()` is a post-selector-rendering
         # path to the dependency. So in order to change the recipe file, we need
         # to relocate `git`, relative to the raw file.
+        if not message.section:
+            return False
         fixed = False
         recipe = self.unrendered_recipe
+        try:
+            all_deps: Final = recipe.get_all_dependencies()
+        except (KeyError, ValueError):
+            self.message(title_in=_utils.GET_ALL_DEPENDENCIES_ERROR_MESSAGE)
+            return False
         problem_paths: set[str] = set()
-        all_deps = recipe.get_all_dependencies()
         for output in all_deps:
             for dep in all_deps[output]:
                 if dep.data.name != "git" or dep.path in problem_paths:

--- a/anaconda_linter/lint/check_multi_output.py
+++ b/anaconda_linter/lint/check_multi_output.py
@@ -5,6 +5,8 @@ Description:    Contains linter checks for multi-output based rules.
 
 from __future__ import annotations
 
+from conda_recipe_manager.parser.recipe_reader_deps import RecipeReaderDeps
+
 from anaconda_linter import utils as _utils
 from anaconda_linter.lint import LintCheck, Severity
 
@@ -34,15 +36,17 @@ class outputs_not_unique(LintCheck):
     and are not the same as the package name.
     """
 
-    def check_recipe_legacy(self, recipe) -> None:
-        if outputs := recipe.get("outputs", None):
-            unique_names = [recipe.get("package/name")]
-            output_names = [recipe.get(f"outputs/{n}/name", "") for n in range(len(outputs))]
-            for n, name in enumerate(output_names):
-                if name in unique_names:
-                    self.message(section=f"outputs/{n}/name", output=n)
-                else:
-                    unique_names.append(name)
+    def check_recipe(self, recipe_name: str, arch_name: str, recipe: RecipeReaderDeps) -> None:
+        unique_names: set[str] = set()
+        for output in recipe.get_package_paths():
+            name_path = "/package/name" if output == "/" else recipe.append_to_path(output, "/name")
+            if not recipe.contains_value(name_path):
+                self.message(section=name_path, title_in="Failed to find package name, cannot run this check.")
+                continue
+            name = recipe.get_value(name_path)
+            if name in unique_names:
+                self.message(section=name_path)
+            unique_names.add(name)
 
 
 class no_global_test(LintCheck):

--- a/anaconda_linter/lint/check_multi_output.py
+++ b/anaconda_linter/lint/check_multi_output.py
@@ -41,7 +41,9 @@ class outputs_not_unique(LintCheck):
         for output in recipe.get_package_paths():
             name_path = "/package/name" if output == "/" else recipe.append_to_path(output, "/name")
             if not recipe.contains_value(name_path):
-                self.message(section=name_path, title_in="Failed to find package name, cannot run this check.")
+                self.message(
+                    section=name_path, title_in="Failed to find package or output name, cannot run this check."
+                )
                 continue
             name = recipe.get_value(name_path)
             if name in unique_names:

--- a/anaconda_linter/utils.py
+++ b/anaconda_linter/utils.py
@@ -16,12 +16,16 @@ from pathlib import Path
 from typing import Any, Final, Optional, Sequence
 
 import requests
-from conda_recipe_manager.parser.recipe_parser_deps import RecipeParserDeps
 from jsonschema import validate
 from percy.render.recipe import Recipe
 from ruamel.yaml import YAML
 
 HTTP_TIMEOUT: Final[int] = 120
+
+GET_ALL_DEPENDENCIES_ERROR_MESSAGE: Final[str] = (
+    "Failed to get all dependencies because package or output "
+    "names are missing or duplicated, cannot run this check/auto-fix."
+)
 
 logger = logging.getLogger(__name__)
 
@@ -278,41 +282,3 @@ def get_deps(recipe: Recipe, sections: Optional[list[str]] = None, outputs: bool
     :param outputs: (Optional) Set to True for recipes that have an `outputs` section
     """
     return list(get_deps_dict(recipe, sections, outputs).keys())
-
-
-def _remove_single_dep_by_name_crm(
-    recipe_parser: RecipeParserDeps,
-    deps_to_remove: set[str],
-) -> bool:
-    """
-    Removes the dependencies specified by name
-
-    :param recipe_parser: The parser of the original recipe
-    :param deps_to_remove: Set of dependency names to remove
-    :raises ValueError: If the remove operation fails
-    :returns: Whether the remove operation is complete
-    """
-    all_deps = recipe_parser.get_all_dependencies()
-    for package_name in all_deps:
-        for dep in all_deps[package_name]:
-            if dep.data.name not in deps_to_remove:
-                continue
-            if not recipe_parser.remove_dependency(dep):
-                raise ValueError(f"Failed to remove dependency {dep.data.name} from {package_name}")
-            return False
-    return True
-
-
-def remove_deps_by_name_crm(
-    recipe_parser: RecipeParserDeps,
-    deps_to_remove: set[str],
-) -> None:
-    """
-    Removes the dependencies specified by name
-
-    :param recipe_parser: The parser of the original recipe
-    :param deps_to_remove: Set of dependency names to remove
-    :raises ValueError: If the remove operation fails
-    """
-    while not _remove_single_dep_by_name_crm(recipe_parser, deps_to_remove):
-        pass

--- a/tests/lint/test_multi_output.py
+++ b/tests/lint/test_multi_output.py
@@ -69,21 +69,6 @@ def test_outputs_not_unique_bad_package_name(base_yaml: str) -> None:
     assert len(messages) == 1 and "not unique" in messages[0].title
 
 
-def test_output_message(base_yaml: str) -> None:
-    yaml_str = (
-        base_yaml
-        + """
-        outputs:
-          - name: output1
-          - name: output2
-          - name: output2
-        """
-    )
-    lint_check = "outputs_not_unique"
-    messages = check(lint_check, yaml_str)
-    assert len(messages) == 1 and messages[0].title.startswith('output "output2": ')
-
-
 def test_outputs_not_unique_bad(base_yaml: str) -> None:
     yaml_str = (
         base_yaml

--- a/tests/lint/test_multi_output.py
+++ b/tests/lint/test_multi_output.py
@@ -6,7 +6,7 @@ Description:    Tests multi-output-based rules
 from __future__ import annotations
 
 import pytest
-from conftest import check
+from conftest import assert_lint_messages, assert_no_lint_message, check
 
 
 def test_output_missing_name_good(base_yaml: str) -> None:
@@ -41,47 +41,27 @@ def test_output_missing_name_bad(base_yaml: str) -> None:
     assert len(messages) == 2 and all("has no name" in msg.title for msg in messages)
 
 
-def test_outputs_not_unique_good(base_yaml: str) -> None:
-    yaml_str = (
-        base_yaml
-        + """
-        outputs:
-          - name: output1
-          - name: output2
-        """
+@pytest.mark.parametrize(
+    "file,",
+    [
+        "outputs_not_unique/outputs_unique.yaml",
+    ],
+)
+def test_outputs_not_unique_outputs_unique(file: str) -> None:
+    assert_no_lint_message(recipe_file=file, lint_check="outputs_not_unique")
+
+
+@pytest.mark.parametrize(
+    "file,msg_count",
+    [
+        ("outputs_not_unique/outputs_not_unique.yaml", 2),
+        ("outputs_not_unique/outputs_not_unique_package_name.yaml", 1),
+    ],
+)
+def test_outputs_not_unique_outputs_not_unique(file: str, msg_count: str) -> None:
+    assert_lint_messages(
+        recipe_file=file, lint_check="outputs_not_unique", msg_title="Output name is not unique", msg_count=msg_count
     )
-    lint_check = "outputs_not_unique"
-    messages = check(lint_check, yaml_str)
-    assert len(messages) == 0
-
-
-def test_outputs_not_unique_bad_package_name(base_yaml: str) -> None:
-    yaml_str = (
-        base_yaml
-        + """
-        outputs:
-          - name: output1
-          - name: test_package
-        """
-    )
-    lint_check = "outputs_not_unique"
-    messages = check(lint_check, yaml_str)
-    assert len(messages) == 1 and "not unique" in messages[0].title
-
-
-def test_outputs_not_unique_bad(base_yaml: str) -> None:
-    yaml_str = (
-        base_yaml
-        + """
-        outputs:
-          - name: output1
-          - name: output2
-          - name: output2
-        """
-    )
-    lint_check = "outputs_not_unique"
-    messages = check(lint_check, yaml_str)
-    assert len(messages) == 1 and "not unique" in messages[0].title
 
 
 def test_no_global_test_good(base_yaml: str) -> None:

--- a/tests/test_aux_files/outputs_not_unique/outputs_not_unique.yaml
+++ b/tests/test_aux_files/outputs_not_unique/outputs_not_unique.yaml
@@ -1,0 +1,19 @@
+package:
+  name: package_name
+  version: 0.0.1
+
+build:
+  number: 0
+
+requirements:
+  host:
+    - python
+  run:
+    - python
+
+outputs:
+  - name: output1
+  - name: output2
+  - name: output3
+  - name: output2
+  - name: output3

--- a/tests/test_aux_files/outputs_not_unique/outputs_not_unique_package_name.yaml
+++ b/tests/test_aux_files/outputs_not_unique/outputs_not_unique_package_name.yaml
@@ -1,0 +1,17 @@
+package:
+  name: package_name
+  version: 0.0.1
+
+build:
+  number: 0
+
+requirements:
+  host:
+    - python
+  run:
+    - python
+
+outputs:
+  - name: output1
+  - name: output2
+  - name: package_name

--- a/tests/test_aux_files/outputs_not_unique/outputs_unique.yaml
+++ b/tests/test_aux_files/outputs_not_unique/outputs_unique.yaml
@@ -1,0 +1,16 @@
+package:
+  name: package_name
+  version: 0.0.1
+
+build:
+  number: 0
+
+requirements:
+  host:
+    - python
+  run:
+    - python
+
+outputs:
+  - name: output1
+  - name: output2


### PR DESCRIPTION
This PR updates:
- the `outputs_not_unique` linter rule
- `outputs_not_unique` testing
- adds `get_all_dependencies()` exception handling to all rules