### PR TITLE
New Linter Rule: m2_must_be_updated_to_msys2

### DIFF
--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -395,7 +395,7 @@ class m2_must_be_updated_to_msys2(LintCheck):
         problem_paths: set[str] = set()
         for output in all_deps:
             for dep in all_deps[output]:
-                if dep.path in problem_paths or not dep.data.name.startswith("m2-"):
+                if dep.path in problem_paths or not (dep.data.name.startswith("m2-") or dep.data.name == "posix"):
                     continue
                 self.message(dep.data.name, section=dep.path)
                 problem_paths.add(dep.path)

--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -385,7 +385,7 @@ class build_tools_must_be_in_build(LintCheck):
 
 class m2_must_be_updated_to_msys2(LintCheck):
     """
-    The m2 tool {} should be updated to msys2.
+    The m2-* package {} should be updated to msys2-*.
     """
 
     def check_recipe(self, recipe_name: str, arch_name: str, recipe: RecipeReaderDeps) -> None:

--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -383,6 +383,24 @@ class build_tools_must_be_in_build(LintCheck):
                 problem_paths.add(dep.path)
 
 
+class m2_must_be_updated_to_msys2(LintCheck):
+    """
+    The m2 tool {} should be updated to msys2.
+    """
+
+    def check_recipe(self, recipe_name: str, arch_name: str, recipe: RecipeReaderDeps) -> None:
+        all_deps: Final = self._get_all_dependencies(recipe)
+        if all_deps is None:
+            return
+        problem_paths: set[str] = set()
+        for output in all_deps:
+            for dep in all_deps[output]:
+                if dep.path in problem_paths or not dep.data.name.startswith("m2-"):
+                    continue
+                self.message(dep.data.name, section=dep.path)
+                problem_paths.add(dep.path)
+
+
 class python_build_tool_in_run(LintCheck):
     """
     The python build tool {} is in run depends

--- a/anaconda_linter/lint_names.md
+++ b/anaconda_linter/lint_names.md
@@ -2,6 +2,8 @@ avoid_noarch
 
 build_tools_must_be_in_build
 
+m2_must_be_updated_to_msys2
+
 compilers_must_be_in_build
 
 conda_render_failure

--- a/tests/lint/test_build_help.py
+++ b/tests/lint/test_build_help.py
@@ -411,7 +411,7 @@ def test_m2_must_be_updated_to_msys2_invalid(file: str) -> None:
     Test that the m2_must_be_updated_to_msys2 lint check fails when the recipe
     has m2 tools in the build section.
     """
-    m2_tools = ["m2-bison", "m2-diffutils", "m2-flex", "m2-patch", "m2-posix"]
+    m2_tools = ["m2-bison", "m2-diffutils", "m2-flex", "m2-patch"]
     msg_title = [f"The m2-* package {tool} should be updated to msys2-*" for tool in m2_tools]
     assert_lint_messages(
         recipe_file=file,

--- a/tests/lint/test_build_help.py
+++ b/tests/lint/test_build_help.py
@@ -389,6 +389,41 @@ def test_build_tools_must_be_in_build_invalid(file: str, msg_count: int) -> None
 @pytest.mark.parametrize(
     "file,",
     [
+        "m2_must_be_updated_to_msys2/all_msys2.yaml",
+    ],
+)
+def test_m2_must_be_updated_to_msys2_valid(file: str) -> None:
+    """
+    Test that the m2_must_be_updated_to_msys2 lint check passes when the recipe
+    has all msys2 tools in the build section.
+    """
+    assert_no_lint_message(recipe_file=file, lint_check="m2_must_be_updated_to_msys2")
+
+
+@pytest.mark.parametrize(
+    "file,",
+    [
+        "m2_must_be_updated_to_msys2/all_m2.yaml",
+    ],
+)
+def test_m2_must_be_updated_to_msys2_invalid(file: str) -> None:
+    """
+    Test that the m2_must_be_updated_to_msys2 lint check fails when the recipe
+    has m2 tools in the build section.
+    """
+    m2_tools = ["m2-bison", "m2-diffutils", "m2-flex", "m2-patch", "m2-posix"]
+    msg_title = [f"The m2 tool {tool} should be updated to msys2" for tool in m2_tools]
+    assert_lint_messages(
+        recipe_file=file,
+        lint_check="m2_must_be_updated_to_msys2",
+        msg_title=msg_title,
+        msg_count=len(m2_tools),
+    )
+
+
+@pytest.mark.parametrize(
+    "file,",
+    [
         "python_build_tool_in_run/single_output_in_host.yaml",
         "python_build_tool_in_run/multi_output_in_host.yaml",
     ],

--- a/tests/lint/test_build_help.py
+++ b/tests/lint/test_build_help.py
@@ -396,6 +396,8 @@ def test_m2_must_be_updated_to_msys2_valid(file: str) -> None:
     """
     Test that the m2_must_be_updated_to_msys2 lint check passes when the recipe
     has all msys2 tools in the build section.
+
+    :param file: The file to test
     """
     assert_no_lint_message(recipe_file=file, lint_check="m2_must_be_updated_to_msys2")
 
@@ -410,6 +412,8 @@ def test_m2_must_be_updated_to_msys2_invalid(file: str) -> None:
     """
     Test that the m2_must_be_updated_to_msys2 lint check fails when the recipe
     has m2 tools in the build section.
+
+    :param file: The file to test
     """
     m2_tools = ["m2-bison", "m2-diffutils", "m2-flex", "m2-patch", "posix"]
     msg_title = [f"The m2-* package {tool} should be updated to msys2-*" for tool in m2_tools]

--- a/tests/lint/test_build_help.py
+++ b/tests/lint/test_build_help.py
@@ -412,7 +412,7 @@ def test_m2_must_be_updated_to_msys2_invalid(file: str) -> None:
     has m2 tools in the build section.
     """
     m2_tools = ["m2-bison", "m2-diffutils", "m2-flex", "m2-patch", "m2-posix"]
-    msg_title = [f"The m2 tool {tool} should be updated to msys2" for tool in m2_tools]
+    msg_title = [f"The m2-* package {tool} should be updated to msys2-*" for tool in m2_tools]
     assert_lint_messages(
         recipe_file=file,
         lint_check="m2_must_be_updated_to_msys2",

--- a/tests/lint/test_build_help.py
+++ b/tests/lint/test_build_help.py
@@ -6,6 +6,7 @@ Description:    Tests build section rules
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Final
 
 import pytest
 from conftest import assert_lint_messages, assert_no_lint_message, check, check_dir
@@ -415,8 +416,8 @@ def test_m2_must_be_updated_to_msys2_invalid(file: str) -> None:
 
     :param file: The file to test
     """
-    m2_tools = ["m2-bison", "m2-diffutils", "m2-flex", "m2-patch", "posix"]
-    msg_title = [f"The m2-* package {tool} should be updated to msys2-*" for tool in m2_tools]
+    m2_tools: Final = ["m2-bison", "m2-diffutils", "m2-flex", "m2-patch", "posix"]
+    msg_title: Final = [f"The m2-* package {tool} should be updated to msys2-*" for tool in m2_tools]
     assert_lint_messages(
         recipe_file=file,
         lint_check="m2_must_be_updated_to_msys2",

--- a/tests/lint/test_build_help.py
+++ b/tests/lint/test_build_help.py
@@ -411,7 +411,7 @@ def test_m2_must_be_updated_to_msys2_invalid(file: str) -> None:
     Test that the m2_must_be_updated_to_msys2 lint check fails when the recipe
     has m2 tools in the build section.
     """
-    m2_tools = ["m2-bison", "m2-diffutils", "m2-flex", "m2-patch"]
+    m2_tools = ["m2-bison", "m2-diffutils", "m2-flex", "m2-patch", "posix"]
     msg_title = [f"The m2-* package {tool} should be updated to msys2-*" for tool in m2_tools]
     assert_lint_messages(
         recipe_file=file,

--- a/tests/test_aux_files/m2_must_be_updated_to_msys2/all_m2.yaml
+++ b/tests/test_aux_files/m2_must_be_updated_to_msys2/all_m2.yaml
@@ -1,0 +1,11 @@
+package:
+  name: test
+  version: 0.1.0
+
+requirements:
+  build:
+    - m2-bison
+    - m2-diffutils
+    - m2-flex
+    - m2-patch
+    - m2-posix

--- a/tests/test_aux_files/m2_must_be_updated_to_msys2/all_m2.yaml
+++ b/tests/test_aux_files/m2_must_be_updated_to_msys2/all_m2.yaml
@@ -8,3 +8,4 @@ requirements:
     - m2-diffutils
     - m2-flex
     - m2-patch
+    - posix

--- a/tests/test_aux_files/m2_must_be_updated_to_msys2/all_m2.yaml
+++ b/tests/test_aux_files/m2_must_be_updated_to_msys2/all_m2.yaml
@@ -8,4 +8,3 @@ requirements:
     - m2-diffutils
     - m2-flex
     - m2-patch
-    - m2-posix

--- a/tests/test_aux_files/m2_must_be_updated_to_msys2/all_msys2.yaml
+++ b/tests/test_aux_files/m2_must_be_updated_to_msys2/all_msys2.yaml
@@ -1,0 +1,11 @@
+package:
+  name: test
+  version: 0.1.0
+
+requirements:
+  build:
+    - msys2-bison
+    - msys2-diffutils
+    - msys2-flex
+    - msys2-patch
+    - msys2-posix


### PR DESCRIPTION
This rule finds any `m2-*`  dependencies and alerts the user to switch to `msys2-*`.