### PR TITLE
New Linter Rule: m2w64_must_be_updated_to_ucrt64

### DIFF
--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -383,6 +383,24 @@ class build_tools_must_be_in_build(LintCheck):
                 problem_paths.add(dep.path)
 
 
+class m2w64_must_be_updated_to_ucrt64(LintCheck):
+    """
+    The m2w64-* package {} should be updated to ucrt64-*.
+    """
+
+    def check_recipe(self, recipe_name: str, arch_name: str, recipe: RecipeReaderDeps) -> None:
+        all_deps: Final = self._get_all_dependencies(recipe)
+        if all_deps is None:
+            return
+        problem_paths: set[str] = set()
+        for output in all_deps:
+            for dep in all_deps[output]:
+                if dep.path in problem_paths or not dep.data.name.startswith("m2w64-"):
+                    continue
+                self.message(dep.data.name, section=dep.path)
+                problem_paths.add(dep.path)
+
+
 class python_build_tool_in_run(LintCheck):
     """
     The python build tool {} is in run depends

--- a/anaconda_linter/lint/check_build_help.py
+++ b/anaconda_linter/lint/check_build_help.py
@@ -386,6 +386,9 @@ class build_tools_must_be_in_build(LintCheck):
 class m2w64_must_be_updated_to_ucrt64(LintCheck):
     """
     The m2w64-* package {} should be updated to ucrt64-*.
+
+    Exception:
+    - m2w64-toolchain -> ucrt64-gcc-toolchain
     """
 
     def check_recipe(self, recipe_name: str, arch_name: str, recipe: RecipeReaderDeps) -> None:

--- a/anaconda_linter/lint_names.md
+++ b/anaconda_linter/lint_names.md
@@ -2,6 +2,8 @@ avoid_noarch
 
 build_tools_must_be_in_build
 
+m2w64_must_be_updated_to_ucrt64
+
 compilers_must_be_in_build
 
 conda_render_failure

--- a/tests/lint/test_build_help.py
+++ b/tests/lint/test_build_help.py
@@ -397,6 +397,8 @@ def test_m2w64_must_be_updated_to_ucrt64_valid(file: str) -> None:
     """
     Test that the m2w64_must_be_updated_to_ucrt64 lint check passes when the recipe
     has all ucrt64 tools in the build section.
+
+    :param file: The file to test
     """
     assert_no_lint_message(recipe_file=file, lint_check="m2w64_must_be_updated_to_ucrt64")
 
@@ -411,6 +413,8 @@ def test_m2w64_must_be_updated_to_ucrt64_invalid(file: str) -> None:
     """
     Test that the m2w64_must_be_updated_to_ucrt64 lint check fails when the recipe
     has m2w64 tools in the build section.
+
+    :param file: The file to test
     """
     m2w64_tools: Final = ["m2w64-toolchain", "m2w64-sysroot"]
     msg_title: Final = [f"The m2w64-* package {tool} should be updated to ucrt64-*" for tool in m2w64_tools]

--- a/tests/lint/test_build_help.py
+++ b/tests/lint/test_build_help.py
@@ -409,7 +409,7 @@ def test_m2w64_must_be_updated_to_ucrt64_valid(file: str) -> None:
 def test_m2w64_must_be_updated_to_ucrt64_invalid(file: str) -> None:
     """
     Test that the m2w64_must_be_updated_to_ucrt64 lint check fails when the recipe
-    has all m2w64 tools in the build section.
+    has m2w64 tools in the build section.
     """
     m2w64_tools = ["m2w64-toolchain", "m2w64-sysroot"]
     msg_title = [f"The m2w64-* package {tool} should be updated to ucrt64-*" for tool in m2w64_tools]

--- a/tests/lint/test_build_help.py
+++ b/tests/lint/test_build_help.py
@@ -416,7 +416,7 @@ def test_m2w64_must_be_updated_to_ucrt64_invalid(file: str) -> None:
 
     :param file: The file to test
     """
-    m2w64_tools: Final = ["m2w64-toolchain", "m2w64-sysroot"]
+    m2w64_tools: Final = ["m2w64-toolchain", "m2w64-xz"]
     msg_title: Final = [f"The m2w64-* package {tool} should be updated to ucrt64-*" for tool in m2w64_tools]
     assert_lint_messages(
         recipe_file=file, lint_check="m2w64_must_be_updated_to_ucrt64", msg_title=msg_title, msg_count=len(m2w64_tools)

--- a/tests/lint/test_build_help.py
+++ b/tests/lint/test_build_help.py
@@ -389,6 +389,38 @@ def test_build_tools_must_be_in_build_invalid(file: str, msg_count: int) -> None
 @pytest.mark.parametrize(
     "file,",
     [
+        "m2w64_must_be_updated_to_ucrt64/all_ucrt64.yaml",
+    ],
+)
+def test_m2w64_must_be_updated_to_ucrt64_valid(file: str) -> None:
+    """
+    Test that the m2w64_must_be_updated_to_ucrt64 lint check passes when the recipe
+    has all ucrt64 tools in the build section.
+    """
+    assert_no_lint_message(recipe_file=file, lint_check="m2w64_must_be_updated_to_ucrt64")
+
+
+@pytest.mark.parametrize(
+    "file,",
+    [
+        "m2w64_must_be_updated_to_ucrt64/all_m2w64.yaml",
+    ],
+)
+def test_m2w64_must_be_updated_to_ucrt64_invalid(file: str) -> None:
+    """
+    Test that the m2w64_must_be_updated_to_ucrt64 lint check fails when the recipe
+    has all m2w64 tools in the build section.
+    """
+    m2w64_tools = ["m2w64-toolchain", "m2w64-sysroot"]
+    msg_title = [f"The m2w64-* package {tool} should be updated to ucrt64-*" for tool in m2w64_tools]
+    assert_lint_messages(
+        recipe_file=file, lint_check="m2w64_must_be_updated_to_ucrt64", msg_title=msg_title, msg_count=len(m2w64_tools)
+    )
+
+
+@pytest.mark.parametrize(
+    "file,",
+    [
         "python_build_tool_in_run/single_output_in_host.yaml",
         "python_build_tool_in_run/multi_output_in_host.yaml",
     ],

--- a/tests/lint/test_build_help.py
+++ b/tests/lint/test_build_help.py
@@ -6,6 +6,7 @@ Description:    Tests build section rules
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Final
 
 import pytest
 from conftest import assert_lint_messages, assert_no_lint_message, check, check_dir
@@ -411,8 +412,8 @@ def test_m2w64_must_be_updated_to_ucrt64_invalid(file: str) -> None:
     Test that the m2w64_must_be_updated_to_ucrt64 lint check fails when the recipe
     has m2w64 tools in the build section.
     """
-    m2w64_tools = ["m2w64-toolchain", "m2w64-sysroot"]
-    msg_title = [f"The m2w64-* package {tool} should be updated to ucrt64-*" for tool in m2w64_tools]
+    m2w64_tools: Final = ["m2w64-toolchain", "m2w64-sysroot"]
+    msg_title: Final = [f"The m2w64-* package {tool} should be updated to ucrt64-*" for tool in m2w64_tools]
     assert_lint_messages(
         recipe_file=file, lint_check="m2w64_must_be_updated_to_ucrt64", msg_title=msg_title, msg_count=len(m2w64_tools)
     )

--- a/tests/test_aux_files/m2w64_must_be_updated_to_ucrt64/all_m2w64.yaml
+++ b/tests/test_aux_files/m2w64_must_be_updated_to_ucrt64/all_m2w64.yaml
@@ -5,4 +5,4 @@ package:
 requirements:
   build:
     - m2w64-toolchain
-    - m2w64-sysroot
+    - m2w64-xz

--- a/tests/test_aux_files/m2w64_must_be_updated_to_ucrt64/all_m2w64.yaml
+++ b/tests/test_aux_files/m2w64_must_be_updated_to_ucrt64/all_m2w64.yaml
@@ -1,0 +1,8 @@
+package:
+  name: test
+  version: 0.1.0
+
+requirements:
+  build:
+    - m2w64-toolchain
+    - m2w64-sysroot

--- a/tests/test_aux_files/m2w64_must_be_updated_to_ucrt64/all_ucrt64.yaml
+++ b/tests/test_aux_files/m2w64_must_be_updated_to_ucrt64/all_ucrt64.yaml
@@ -1,0 +1,8 @@
+package:
+  name: test
+  version: 0.1.0
+
+requirements:
+  build:
+    - ucrt64-gcc-toolchain
+    - ucrt64-xz


### PR DESCRIPTION
This new linter rule checks for any `m2w64-*` dependencies in the recipe and alerts the user to update to `ucrt64-*`.